### PR TITLE
Jobber normalt per uke

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     </modules>
 
     <properties>
-        <revision>3.0.0</revision>
+        <revision>2.1.0</revision>
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>
         <java.version>11</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     </modules>
 
     <properties>
-        <revision>2.0.2</revision>
+        <revision>3.0.0</revision>
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>
         <java.version>11</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     </modules>
 
     <properties>
-        <revision>2.1.0</revision>
+        <revision>3.0.0</revision>
         <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>
         <java.version>11</java.version>

--- a/soknad-felles/src/main/java/no/nav/k9/søknad/felles/Bosteder.java
+++ b/soknad-felles/src/main/java/no/nav/k9/søknad/felles/Bosteder.java
@@ -8,6 +8,8 @@ import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
 
 public class Bosteder {
     public final Map<Periode, BostedPeriodeInfo> perioder;
@@ -31,12 +33,12 @@ public class Bosteder {
         }
 
         public Builder perioder(Map<Periode, BostedPeriodeInfo> perioder) {
-            this.perioder.putAll(perioder);
+            leggTilPerioder(this.perioder, perioder);
             return this;
         }
 
         public Builder periode(Periode periode, BostedPeriodeInfo bostedPeriodeInfo) {
-            this.perioder.put(periode, bostedPeriodeInfo);
+            leggTilPeriode(this.perioder, periode, bostedPeriodeInfo);
             return this;
         }
 

--- a/soknad-felles/src/main/java/no/nav/k9/søknad/felles/LovbestemtFerie.java
+++ b/soknad-felles/src/main/java/no/nav/k9/søknad/felles/LovbestemtFerie.java
@@ -9,6 +9,9 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
+
 public class LovbestemtFerie {
     public final Map<Periode, LovbestemtFeriePeriodeInfo> perioder;
 
@@ -31,12 +34,12 @@ public class LovbestemtFerie {
         }
 
         public Builder perioder(Map<Periode, LovbestemtFeriePeriodeInfo> perioder) {
-            this.perioder.putAll(perioder);
+            leggTilPerioder(this.perioder, perioder);
             return this;
         }
 
         public Builder periode(Periode periode, LovbestemtFeriePeriodeInfo lovbestemtFeriePeriodeInfo) {
-            this.perioder.put(periode, lovbestemtFeriePeriodeInfo);
+            leggTilPeriode(this.perioder, periode, lovbestemtFeriePeriodeInfo);
             return this;
         }
 

--- a/soknad-felles/src/main/java/no/nav/k9/søknad/felles/Periode.java
+++ b/soknad-felles/src/main/java/no/nav/k9/søknad/felles/Periode.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.time.LocalDate;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class Periode {
     static final String ÅPEN = "..";
@@ -110,7 +111,51 @@ public class Periode {
     }
 
     public static final class Utils {
+        private Utils() {}
+
         private static final Comparator<Periode> tilOgMedComparator = Comparator.comparing(periode -> periode.tilOgMed);
+
+        public static <PeriodeInfo> Map<Periode, PeriodeInfo> leggTilPeriode(
+                Map<Periode, PeriodeInfo> eksisterende,
+                Periode nyPeriode,
+                PeriodeInfo nyPeriodeInfo) {
+            Objects.requireNonNull(eksisterende);
+            Objects.requireNonNull(nyPeriode);
+            Objects.requireNonNull(nyPeriodeInfo);
+
+            if (eksisterende.containsKey(nyPeriode)) {
+                throw new IllegalArgumentException("Inneholder allerede " + nyPeriode.iso8601);
+            }
+
+            eksisterende.put(nyPeriode,  nyPeriodeInfo);
+            return eksisterende;
+        }
+
+        public static <PeriodeInfo> Map<Periode, PeriodeInfo> leggTilPerioder(
+                Map<Periode, PeriodeInfo> eksisterende,
+                Map<Periode, PeriodeInfo> nye) {
+            Objects.requireNonNull(eksisterende);
+            Objects.requireNonNull(nye);
+            var nyePerioder = nye.keySet();
+
+            var duplikater = eksisterende
+                    .keySet()
+                    .stream()
+                    .filter(nyePerioder::contains)
+                    .collect(Collectors.toSet());
+
+            if (!duplikater.isEmpty()) {
+                var duplikatePerioder = String.join(", ", duplikater
+                        .stream()
+                        .map(it-> it.iso8601)
+                        .collect(Collectors.toSet()));
+                throw new IllegalArgumentException("Inneholder allerede " + duplikatePerioder);
+            }
+
+            eksisterende.putAll(nye);
+            return eksisterende;
+        }
+
 
         public static LocalDate sisteTilOgMedTillatÅpnePerioder(Map<Periode, ?> periodeMap) {
             return sisteTilOgMed(periodeMap);

--- a/soknad-felles/src/main/java/no/nav/k9/søknad/felles/Periode.java
+++ b/soknad-felles/src/main/java/no/nav/k9/søknad/felles/Periode.java
@@ -115,10 +115,10 @@ public class Periode {
 
         private static final Comparator<Periode> tilOgMedComparator = Comparator.comparing(periode -> periode.tilOgMed);
 
-        public static <PeriodeInfo> void leggTilPeriode(
-                Map<Periode, PeriodeInfo> perioder,
+        public static <PERIODE_INFO> void leggTilPeriode(
+                Map<Periode, PERIODE_INFO> perioder,
                 Periode nyPeriode,
-                PeriodeInfo nyPeriodeInfo) {
+                PERIODE_INFO nyPeriodeInfo) {
             Objects.requireNonNull(perioder);
             Objects.requireNonNull(nyPeriode);
             Objects.requireNonNull(nyPeriodeInfo);
@@ -130,9 +130,9 @@ public class Periode {
             perioder.put(nyPeriode,  nyPeriodeInfo);
         }
 
-        public static <PeriodeInfo> void leggTilPerioder(
-                Map<Periode, PeriodeInfo> perioder,
-                Map<Periode, PeriodeInfo> nyePerioder) {
+        public static <PERIODE_INFO> void leggTilPerioder(
+                Map<Periode, PERIODE_INFO> perioder,
+                Map<Periode, PERIODE_INFO> nyePerioder) {
             Objects.requireNonNull(perioder);
             Objects.requireNonNull(nyePerioder);
             var nyeKeys = nyePerioder.keySet();

--- a/soknad-felles/src/main/java/no/nav/k9/søknad/felles/Periode.java
+++ b/soknad-felles/src/main/java/no/nav/k9/søknad/felles/Periode.java
@@ -115,33 +115,32 @@ public class Periode {
 
         private static final Comparator<Periode> tilOgMedComparator = Comparator.comparing(periode -> periode.tilOgMed);
 
-        public static <PeriodeInfo> Map<Periode, PeriodeInfo> leggTilPeriode(
-                Map<Periode, PeriodeInfo> eksisterende,
+        public static <PeriodeInfo> void leggTilPeriode(
+                Map<Periode, PeriodeInfo> perioder,
                 Periode nyPeriode,
                 PeriodeInfo nyPeriodeInfo) {
-            Objects.requireNonNull(eksisterende);
+            Objects.requireNonNull(perioder);
             Objects.requireNonNull(nyPeriode);
             Objects.requireNonNull(nyPeriodeInfo);
 
-            if (eksisterende.containsKey(nyPeriode)) {
+            if (perioder.containsKey(nyPeriode)) {
                 throw new IllegalArgumentException("Inneholder allerede " + nyPeriode.iso8601);
             }
 
-            eksisterende.put(nyPeriode,  nyPeriodeInfo);
-            return eksisterende;
+            perioder.put(nyPeriode,  nyPeriodeInfo);
         }
 
-        public static <PeriodeInfo> Map<Periode, PeriodeInfo> leggTilPerioder(
-                Map<Periode, PeriodeInfo> eksisterende,
-                Map<Periode, PeriodeInfo> nye) {
-            Objects.requireNonNull(eksisterende);
-            Objects.requireNonNull(nye);
-            var nyePerioder = nye.keySet();
+        public static <PeriodeInfo> void leggTilPerioder(
+                Map<Periode, PeriodeInfo> perioder,
+                Map<Periode, PeriodeInfo> nyePerioder) {
+            Objects.requireNonNull(perioder);
+            Objects.requireNonNull(nyePerioder);
+            var nyeKeys = nyePerioder.keySet();
 
-            var duplikater = eksisterende
+            var duplikater = perioder
                     .keySet()
                     .stream()
-                    .filter(nyePerioder::contains)
+                    .filter(nyeKeys::contains)
                     .collect(Collectors.toSet());
 
             if (!duplikater.isEmpty()) {
@@ -152,8 +151,7 @@ public class Periode {
                 throw new IllegalArgumentException("Inneholder allerede " + duplikatePerioder);
             }
 
-            eksisterende.putAll(nye);
-            return eksisterende;
+            perioder.putAll(nyePerioder);
         }
 
 

--- a/soknad-felles/src/test/java/no/nav/k9/søknad/PeriodeTest.java
+++ b/soknad-felles/src/test/java/no/nav/k9/søknad/PeriodeTest.java
@@ -111,16 +111,16 @@ public class PeriodeTest {
         var periode2 = Periode.parse("2020-04-04/..");
         var periode3 = Periode.parse("2020-05-05/2020-06-06");
 
-        var eksisterende = Map.of(
+        var perioder = Map.of(
                 periode1, true,
                 periode2, true
         );
-        var nytt = Map.of(
+        var nyePerioder = Map.of(
                 periode1, true,
                 periode2, true,
                 periode3, true
         );
-        leggTilPerioder(eksisterende, nytt);
+        leggTilPerioder(perioder, nyePerioder);
     }
 
     @Test
@@ -129,18 +129,17 @@ public class PeriodeTest {
         var periode2 = Periode.parse("2020-04-04/..");
         var periode3 = Periode.parse("2020-05-05/2020-06-06");
 
-        var eksisterende = new HashMap<>(Map.of(
+        var perioder = new HashMap<>(Map.of(
                 periode1, true,
                 periode2, true
         ));
-        var nytt = Map.of(
+        var nyePerioder = Map.of(
                 periode3, true
         );
 
-        var oppdatert = leggTilPerioder(eksisterende, nytt);
-        assertEquals(3, oppdatert.size());
-        assertTrue(oppdatert.keySet().containsAll(Set.of(periode1, periode2, periode3)));
-        assertEquals(eksisterende, oppdatert);
+        leggTilPerioder(perioder, nyePerioder);
+        assertEquals(3, perioder.size());
+        assertTrue(perioder.keySet().containsAll(Set.of(periode1, periode2, periode3)));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -148,12 +147,12 @@ public class PeriodeTest {
         var periode1 = Periode.parse("2020-01-01/2021-01-01");
         var periode2 = Periode.parse("2020-04-04/..");
 
-        var eksisterende = Map.of(
+        var perioder = Map.of(
                 periode1, true,
                 periode2, true
         );
 
-        leggTilPeriode(eksisterende, periode1, true);
+        leggTilPeriode(perioder, periode1, true);
     }
 
     @Test
@@ -161,13 +160,12 @@ public class PeriodeTest {
         var periode1 = Periode.parse("2020-01-01/2021-01-01");
         var periode2 = Periode.parse("2020-04-04/..");
 
-        var eksisterende = new HashMap<>(Map.of(
+        var perioder = new HashMap<>(Map.of(
                 periode1, true
         ));
 
-        var oppdatert = leggTilPeriode(eksisterende, periode2, true);
-        assertEquals(2, oppdatert.size());
-        assertTrue(oppdatert.keySet().containsAll(Set.of(periode1, periode2)));
-        assertEquals(eksisterende, oppdatert);
+        leggTilPeriode(perioder, periode2, true);
+        assertEquals(2, perioder.size());
+        assertTrue(perioder.keySet().containsAll(Set.of(periode1, periode2)));
     }
 }

--- a/soknad-felles/src/test/java/no/nav/k9/søknad/PeriodeTest.java
+++ b/soknad-felles/src/test/java/no/nav/k9/søknad/PeriodeTest.java
@@ -4,9 +4,13 @@ import no.nav.k9.søknad.felles.Periode;
 import org.junit.Test;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
+import static org.junit.Assert.*;
 
 
 public class PeriodeTest {
@@ -99,5 +103,71 @@ public class PeriodeTest {
         lukketPeriode = Periode.forsikreLukketPeriode(Periode.parse("2020-02-01/2020-02-03"), LocalDate.parse("2022-01-01"));
         assertEquals(LocalDate.parse("2020-02-01"), lukketPeriode.fraOgMed);
         assertEquals(LocalDate.parse("2020-02-03"), lukketPeriode.tilOgMed);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void TestLeggTilPerioderMedDuplikater() {
+        var periode1 = Periode.parse("2020-01-01/2021-01-01");
+        var periode2 = Periode.parse("2020-04-04/..");
+        var periode3 = Periode.parse("2020-05-05/2020-06-06");
+
+        var eksisterende = Map.of(
+                periode1, true,
+                periode2, true
+        );
+        var nytt = Map.of(
+                periode1, true,
+                periode2, true,
+                periode3, true
+        );
+        leggTilPerioder(eksisterende, nytt);
+    }
+
+    @Test
+    public void TestLeggTilPerioderUtenDuplikater() {
+        var periode1 = Periode.parse("2020-01-01/2021-01-01");
+        var periode2 = Periode.parse("2020-04-04/..");
+        var periode3 = Periode.parse("2020-05-05/2020-06-06");
+
+        var eksisterende = new HashMap<>(Map.of(
+                periode1, true,
+                periode2, true
+        ));
+        var nytt = Map.of(
+                periode3, true
+        );
+
+        var oppdatert = leggTilPerioder(eksisterende, nytt);
+        assertEquals(3, oppdatert.size());
+        assertTrue(oppdatert.keySet().containsAll(Set.of(periode1, periode2, periode3)));
+        assertEquals(eksisterende, oppdatert);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void TestLeggTilPeriodeMedDuplikater() {
+        var periode1 = Periode.parse("2020-01-01/2021-01-01");
+        var periode2 = Periode.parse("2020-04-04/..");
+
+        var eksisterende = Map.of(
+                periode1, true,
+                periode2, true
+        );
+
+        leggTilPeriode(eksisterende, periode1, true);
+    }
+
+    @Test
+    public void TestLeggTilPeriodeUtenDuplikater() {
+        var periode1 = Periode.parse("2020-01-01/2021-01-01");
+        var periode2 = Periode.parse("2020-04-04/..");
+
+        var eksisterende = new HashMap<>(Map.of(
+                periode1, true
+        ));
+
+        var oppdatert = leggTilPeriode(eksisterende, periode2, true);
+        assertEquals(2, oppdatert.size());
+        assertTrue(oppdatert.keySet().containsAll(Set.of(periode1, periode2)));
+        assertEquals(eksisterende, oppdatert);
     }
 }

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Arbeidstaker.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Arbeidstaker.java
@@ -8,6 +8,7 @@ import no.nav.k9.søknad.felles.Periode;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -87,10 +88,15 @@ public class Arbeidstaker {
          */
         public final BigDecimal skalJobbeProsent;
 
+        public final Duration jobberNormaltPerUke;
+
         private ArbeidstakerPeriodeInfo(
                 @JsonProperty("skalJobbeProsent")
-                BigDecimal skalJobbeProsent) {
-            this.skalJobbeProsent = (skalJobbeProsent == null) ? null : skalJobbeProsent.setScale(2, RoundingMode.HALF_UP);
+                BigDecimal skalJobbeProsent,
+                @JsonProperty("jobberNormaltPerUke")
+                Duration jobberNormaltPerUke) {
+            this.skalJobbeProsent = skalJobbeProsent == null ? null : skalJobbeProsent.setScale(2, RoundingMode.HALF_UP);
+            this.jobberNormaltPerUke = jobberNormaltPerUke;
         }
 
         public static Builder builder() {
@@ -99,6 +105,7 @@ public class Arbeidstaker {
 
         public static final class Builder {
             private BigDecimal skalJobbeProsent;
+            private Duration jobberNormaltPerUke;
 
             private Builder() {}
 
@@ -107,9 +114,15 @@ public class Arbeidstaker {
                 return this;
             }
 
+            public Builder jobberNormaltPerUke(Duration jobberNormaltPerUke) {
+                this.jobberNormaltPerUke = jobberNormaltPerUke;
+                return this;
+            }
+
             public ArbeidstakerPeriodeInfo build() {
                 return new ArbeidstakerPeriodeInfo(
-                        skalJobbeProsent
+                        skalJobbeProsent,
+                        jobberNormaltPerUke
                 );
             }
         }

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Arbeidstaker.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Arbeidstaker.java
@@ -15,6 +15,9 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
+
 public class Arbeidstaker {
     public final NorskIdentitetsnummer norskIdentitetsnummer;
     public final Organisasjonsnummer organisasjonsnummer;
@@ -52,12 +55,12 @@ public class Arbeidstaker {
         }
 
         public Builder perioder(Map<Periode, ArbeidstakerPeriodeInfo> perioder) {
-            this.perioder.putAll(perioder);
+            leggTilPerioder(this.perioder, perioder);
             return this;
         }
 
         public Builder periode(Periode periode, ArbeidstakerPeriodeInfo arbeidstakerPeriodeInfo) {
-            this.perioder.put(periode, arbeidstakerPeriodeInfo);
+            leggTilPeriode(this.perioder, periode, arbeidstakerPeriodeInfo);
             return this;
         }
 

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Beredskap.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Beredskap.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
+
 public class Beredskap {
     public final Map<Periode, BeredskapPeriodeInfo> perioder;
 
@@ -32,12 +35,12 @@ public class Beredskap {
         }
 
         public Builder perioder(Map<Periode, BeredskapPeriodeInfo> perioder) {
-            this.perioder.putAll(perioder);
+            leggTilPerioder(this.perioder, perioder);
             return this;
         }
 
         public Builder periode(Periode periode, BeredskapPeriodeInfo beredskapPeriodeInfo) {
-            this.perioder.put(periode, beredskapPeriodeInfo);
+            leggTilPeriode(this.perioder, periode, beredskapPeriodeInfo);
             return this;
         }
 

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Frilanser.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Frilanser.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
+
 public class Frilanser {
 
     public final Map<Periode, FrilanserPeriodeInfo> perioder;
@@ -33,12 +36,12 @@ public class Frilanser {
         }
 
         public Builder perioder(Map<Periode, FrilanserPeriodeInfo> perioder) {
-            this.perioder.putAll(perioder);
+            leggTilPerioder(this.perioder, perioder);
             return this;
         }
 
         public Builder periode(Periode periode, FrilanserPeriodeInfo frilanserPeriodeInfo) {
-            this.perioder.put(periode, frilanserPeriodeInfo);
+            leggTilPeriode(this.perioder, periode, frilanserPeriodeInfo);
             return this;
         }
 

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Nattevåk.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Nattevåk.java
@@ -10,6 +10,10 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
+
+
 public class Nattevåk {
     public final Map<Periode, NattevåkPeriodeInfo> perioder;
 
@@ -32,12 +36,12 @@ public class Nattevåk {
         }
 
         public Builder perioder(Map<Periode, NattevåkPeriodeInfo> perioder) {
-            this.perioder.putAll(perioder);
+            leggTilPerioder(this.perioder, perioder);
             return this;
         }
 
         public Builder periode(Periode periode, NattevåkPeriodeInfo nattevåkPeriodeInfo) {
-            this.perioder.put(periode, nattevåkPeriodeInfo);
+            leggTilPeriode(this.perioder, periode, nattevåkPeriodeInfo);
             return this;
         }
 

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknad.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknad.java
@@ -114,9 +114,26 @@ public class PleiepengerBarnSøknad {
         }
     }
 
+    public static final class Utils {
+        private Utils() {}
+
+        public static boolean alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
+                PleiepengerBarnSøknad søknad) {
+            return søknad.arbeid.arbeidstaker
+                    .stream()
+                    .noneMatch(arbeidstaker ->
+                            arbeidstaker.perioder.values()
+                                    .stream()
+                                    .anyMatch(periodeInfo ->
+                                            periodeInfo.jobberNormaltPerUke == null
+                                    )
+                    );
+        }
+    }
+
     public static final class Builder {
         private static final PleiepengerBarnSøknadValidator validator = new PleiepengerBarnSøknadValidator();
-        private static final Versjon versjon = Versjon.of("2.0.0");
+        private static final Versjon versjon = Versjon.of("1.1.0");
 
         private String json;
         private SøknadId søknadId;

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknad.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknad.java
@@ -114,26 +114,9 @@ public class PleiepengerBarnSøknad {
         }
     }
 
-    public static final class Utils {
-        private Utils() {}
-
-        public static boolean alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
-                PleiepengerBarnSøknad søknad) {
-            return søknad.arbeid.arbeidstaker
-                    .stream()
-                    .noneMatch(arbeidstaker ->
-                            arbeidstaker.perioder.values()
-                                    .stream()
-                                    .anyMatch(periodeInfo ->
-                                            periodeInfo.jobberNormaltPerUke == null
-                                    )
-                    );
-        }
-    }
-
     public static final class Builder {
         private static final PleiepengerBarnSøknadValidator validator = new PleiepengerBarnSøknadValidator();
-        private static final Versjon versjon = Versjon.of("1.1.0");
+        private static final Versjon versjon = Versjon.of("2.0.0");
 
         private String json;
         private SøknadId søknadId;

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknad.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknad.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
+
 import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
 import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
 

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknad.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknad.java
@@ -116,7 +116,7 @@ public class PleiepengerBarnSøknad {
 
     public static final class Builder {
         private static final PleiepengerBarnSøknadValidator validator = new PleiepengerBarnSøknadValidator();
-        private static final Versjon versjon = Versjon.of("1.0.0");
+        private static final Versjon versjon = Versjon.of("2.0.0");
 
         private String json;
         private SøknadId søknadId;

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknad.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknad.java
@@ -14,6 +14,8 @@ import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
 
 public class PleiepengerBarnSøknad {
 
@@ -149,12 +151,12 @@ public class PleiepengerBarnSøknad {
 
 
         public Builder søknadsperiode(Periode periode, SøknadsperiodeInfo søknadsperiodeInfo) {
-            this.søknadsperioder.put(periode, søknadsperiodeInfo);
+            leggTilPeriode(this.søknadsperioder, periode, søknadsperiodeInfo);
             return this;
         }
 
         public Builder søknadsperioder(Map<Periode, SøknadsperiodeInfo> søknadsperioder) {
-            this.søknadsperioder.putAll(søknadsperioder);
+            leggTilPerioder(this.søknadsperioder, søknadsperioder);
             return this;
         }
 

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidator.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidator.java
@@ -141,9 +141,9 @@ public class PleiepengerBarnSøknadValidator extends SøknadValidator<Pleiepenge
                     feil.add(new Feil("arbeid.arbeidstaker[" + i + "].perioder[" + perioder.getKey().iso8601 + "].skalJobbeProsent", "ugylidigProsent", "Skal jobbe prosent må være mellom 0 og 100"));
                 }
                 Duration jobberNormalPerUke = perioder.getValue().jobberNormaltPerUke;
-                if (jobberNormalPerUke != null && jobberNormalPerUke.isNegative()) {
+                if (jobberNormalPerUke == null || jobberNormalPerUke.isNegative()) {
                     feil.add(new Feil("arbeid.arbeidstaker[" + i + "].perioder[" + perioder.getKey().iso8601 + "].jobberNormalPerUke", "ugyldigJobbperiode", "Jobber normalt per uke må settes til en gyldig verdi."));
-                } else if (jobberNormalPerUke != null && jobberNormalPerUke.compareTo(MAKS_INNENFOR_EN_UKE) > 0) {
+                } else if (jobberNormalPerUke.compareTo(MAKS_INNENFOR_EN_UKE) > 0) {
                     feil.add(new Feil("arbeid.arbeidstaker[" + i + "].perioder[" + perioder.getKey().iso8601 + "].jobberNormalPerUke", "ugyldigJobbperiode", "Jobber normalt per uke kan ikke overstige en uke."));
                 }
             }

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidator.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidator.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 
 public class PleiepengerBarnSøknadValidator extends SøknadValidator<PleiepengerBarnSøknad> {
+    private static final Duration MAKS_INNENFOR_EN_UKE = Duration.ofDays(7);
+
     private final PeriodeValidator periodeValidator;
 
     PleiepengerBarnSøknadValidator() {
@@ -137,6 +139,12 @@ public class PleiepengerBarnSøknadValidator extends SøknadValidator<Pleiepenge
                 BigDecimal skalJobbeProsent = perioder.getValue().skalJobbeProsent;
                 if (skalJobbeProsent == null || skalJobbeProsent.doubleValue() < 0 || skalJobbeProsent.doubleValue() > 100) {
                     feil.add(new Feil("arbeid.arbeidstaker[" + i + "].perioder[" + perioder.getKey().iso8601 + "].skalJobbeProsent", "ugylidigProsent", "Skal jobbe prosent må være mellom 0 og 100"));
+                }
+                Duration jobberNormalPerUke = perioder.getValue().jobberNormaltPerUke;
+                if (jobberNormalPerUke == null || jobberNormalPerUke.isNegative()) {
+                    feil.add(new Feil("arbeid.arbeidstaker[" + i + "].perioder[" + perioder.getKey().iso8601 + "].jobberNormalPerUke", "ugyldigJobbperiode", "Jobber normalt per uke må settes til en gyldig verdi."));
+                } else if (jobberNormalPerUke.compareTo(MAKS_INNENFOR_EN_UKE) > 0) {
+                    feil.add(new Feil("arbeid.arbeidstaker[" + i + "].perioder[" + perioder.getKey().iso8601 + "].jobberNormalPerUke", "ugyldigJobbperiode", "Jobber normalt per uke kan ikke overstige en uke."));
                 }
             }
             i++;

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidator.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidator.java
@@ -141,9 +141,9 @@ public class PleiepengerBarnSøknadValidator extends SøknadValidator<Pleiepenge
                     feil.add(new Feil("arbeid.arbeidstaker[" + i + "].perioder[" + perioder.getKey().iso8601 + "].skalJobbeProsent", "ugylidigProsent", "Skal jobbe prosent må være mellom 0 og 100"));
                 }
                 Duration jobberNormalPerUke = perioder.getValue().jobberNormaltPerUke;
-                if (jobberNormalPerUke == null || jobberNormalPerUke.isNegative()) {
+                if (jobberNormalPerUke != null && jobberNormalPerUke.isNegative()) {
                     feil.add(new Feil("arbeid.arbeidstaker[" + i + "].perioder[" + perioder.getKey().iso8601 + "].jobberNormalPerUke", "ugyldigJobbperiode", "Jobber normalt per uke må settes til en gyldig verdi."));
-                } else if (jobberNormalPerUke.compareTo(MAKS_INNENFOR_EN_UKE) > 0) {
+                } else if (jobberNormalPerUke != null && jobberNormalPerUke.compareTo(MAKS_INNENFOR_EN_UKE) > 0) {
                     feil.add(new Feil("arbeid.arbeidstaker[" + i + "].perioder[" + perioder.getKey().iso8601 + "].jobberNormalPerUke", "ugyldigJobbperiode", "Jobber normalt per uke kan ikke overstige en uke."));
                 }
             }

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/SelvstendigNæringsdrivende.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/SelvstendigNæringsdrivende.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
+
 public class SelvstendigNæringsdrivende {
 
     public final Map<Periode, SelvstendigNæringsdrivendePeriodeInfo> perioder;
@@ -33,12 +36,12 @@ public class SelvstendigNæringsdrivende {
         }
 
         public Builder perioder(Map<Periode, SelvstendigNæringsdrivendePeriodeInfo> perioder) {
-            this.perioder.putAll(perioder);
+            leggTilPerioder(this.perioder, perioder);
             return this;
         }
 
         public Builder periode(Periode periode, SelvstendigNæringsdrivendePeriodeInfo selvstendigNæringsdrivendePeriodeInfo) {
-            this.perioder.put(periode, selvstendigNæringsdrivendePeriodeInfo);
+            leggTilPeriode(this.perioder, periode, selvstendigNæringsdrivendePeriodeInfo);
             return this;
         }
 

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Tilsynsordning.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Tilsynsordning.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
+
 public class Tilsynsordning {
 
     public final TilsynsordningSvar iTilsynsordning;
@@ -42,12 +45,12 @@ public class Tilsynsordning {
         }
 
         public Builder opphold(Map<Periode, TilsynsordningOpphold> opphold) {
-            this.opphold.putAll(opphold);
+            leggTilPerioder(this.opphold, opphold);
             return this;
         }
 
-        public Builder opphold(Periode periode, TilsynsordningOpphold duration) {
-            this.opphold.put(periode, duration);
+        public Builder opphold(Periode periode, TilsynsordningOpphold tilsynsordningOpphold) {
+            leggTilPeriode(this.opphold, periode, tilsynsordningOpphold);
             return this;
         }
 

--- a/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Utenlandsopphold.java
+++ b/soknad-pleiepenger-barn/src/main/java/no/nav/k9/søknad/pleiepengerbarn/Utenlandsopphold.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPerioder;
+import static no.nav.k9.søknad.felles.Periode.Utils.leggTilPeriode;
 
 public class Utenlandsopphold {
     public final Map<Periode, UtenlandsoppholdPeriodeInfo> perioder;
@@ -35,12 +37,12 @@ public class Utenlandsopphold {
         }
 
         public Builder perioder(Map<Periode, UtenlandsoppholdPeriodeInfo> perioder) {
-            this.perioder.putAll(perioder);
+            leggTilPerioder(this.perioder, perioder);
             return this;
         }
 
         public Builder periode(Periode periode, UtenlandsoppholdPeriodeInfo utenlandsoppholdPeriodeInfo) {
-            this.perioder.put(periode, utenlandsoppholdPeriodeInfo);
+            leggTilPeriode(this.perioder, periode, utenlandsoppholdPeriodeInfo);
             return this;
         }
 

--- a/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadTest.java
+++ b/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadTest.java
@@ -1,21 +1,9 @@
 package no.nav.k9.søknad.pleiepengerbarn;
 
-import no.nav.k9.søknad.felles.NorskIdentitetsnummer;
-import no.nav.k9.søknad.felles.Organisasjonsnummer;
-import no.nav.k9.søknad.felles.Periode;
 import org.json.JSONException;
 import org.junit.Test;
 
 import org.skyscreamer.jsonassert.JSONAssert;
-
-import java.math.BigDecimal;
-import java.time.Duration;
-import java.time.LocalDate;
-
-import static no.nav.k9.søknad.pleiepengerbarn.PleiepengerBarnSøknad.Utils.alleArbeidstakerPerioderInneholderJobberNormaltPerUke;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 public class PleiepengerBarnSøknadTest {
     @Test
     public void serialiseringAvJsonOgBrukAvBuilderGirSammeResultat() throws JSONException {
@@ -29,73 +17,5 @@ public class PleiepengerBarnSøknadTest {
         String json = TestUtils.jsonForKomplettSøknad();
         PleiepengerBarnSøknad søknad = PleiepengerBarnSøknad.SerDes.deserialize(json);
         JSONAssert.assertEquals(json, PleiepengerBarnSøknad.SerDes.serialize(søknad), true);
-    }
-
-    @Test
-    public void UtilPåOmAlleArbeidstakerPerioderInneholderJobberNormaltPerUke() {
-        final var enTime = Duration.ofHours(1);
-        final var builder = TestUtils.komplettBuilder();
-
-        var arbeid = arbeid(null, null, null);
-        assertFalse(alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
-                builder.arbeid(arbeid).build()
-        ));
-
-        arbeid = arbeid(enTime, null, null);
-        assertFalse(alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
-                builder.arbeid(arbeid).build()
-        ));
-
-        arbeid = arbeid(enTime, enTime, null);
-        assertFalse(alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
-                builder.arbeid(arbeid).build()
-        ));
-
-        arbeid = arbeid(enTime, null, enTime);
-        assertFalse(alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
-                builder.arbeid(arbeid).build()
-        ));
-
-        arbeid = arbeid(enTime, enTime, enTime);
-        assertTrue(alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
-                builder.arbeid(arbeid).build()
-        ));
-    }
-
-    private Arbeid arbeid(
-            Duration jobberNormaltPerUkePeriode1,
-            Duration jobberNormaltPerUkePeriode2,
-            Duration jobberNormaltPerUkePeriode3) {
-        return Arbeid
-                .builder()
-                .arbeidstaker(Arbeidstaker
-                        .builder()
-                        .organisasjonsnummer(Organisasjonsnummer.of("88888888"))
-                        .periode(
-                                Periode.builder().fraOgMed(LocalDate.now()).tilOgMed(LocalDate.now().plusDays(3)).build(),
-                                Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
-                                        .skalJobbeProsent(BigDecimal.valueOf(40.00))
-                                        .jobberNormaltPerUke(jobberNormaltPerUkePeriode1)
-                                        .build())
-                        .periode(
-                                Periode.builder().fraOgMed(LocalDate.now().plusDays(6)).tilOgMed(LocalDate.now().plusDays(10)).build(),
-                                Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
-                                        .skalJobbeProsent(BigDecimal.valueOf(50.00))
-                                        .jobberNormaltPerUke(jobberNormaltPerUkePeriode2)
-                                        .build())
-                        .build()
-                )
-                .arbeidstaker(Arbeidstaker
-                        .builder()
-                        .norskIdentitetsnummer(NorskIdentitetsnummer.of("123"))
-                        .periode(
-                                Periode.builder().fraOgMed(LocalDate.now()).tilOgMed(LocalDate.now().plusDays(3)).build(),
-                                Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
-                                        .skalJobbeProsent(BigDecimal.valueOf(40.00))
-                                        .jobberNormaltPerUke(jobberNormaltPerUkePeriode3)
-                                        .build())
-                        .build()
-                )
-                .build();
     }
 }

--- a/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadTest.java
+++ b/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadTest.java
@@ -1,9 +1,20 @@
 package no.nav.k9.søknad.pleiepengerbarn;
 
+import no.nav.k9.søknad.felles.NorskIdentitetsnummer;
+import no.nav.k9.søknad.felles.Organisasjonsnummer;
+import no.nav.k9.søknad.felles.Periode;
 import org.json.JSONException;
 import org.junit.Test;
 
 import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+
+import static no.nav.k9.søknad.pleiepengerbarn.PleiepengerBarnSøknad.Utils.alleArbeidstakerPerioderInneholderJobberNormaltPerUke;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PleiepengerBarnSøknadTest {
     @Test
@@ -18,5 +29,73 @@ public class PleiepengerBarnSøknadTest {
         String json = TestUtils.jsonForKomplettSøknad();
         PleiepengerBarnSøknad søknad = PleiepengerBarnSøknad.SerDes.deserialize(json);
         JSONAssert.assertEquals(json, PleiepengerBarnSøknad.SerDes.serialize(søknad), true);
+    }
+
+    @Test
+    public void UtilPåOmAlleArbeidstakerPerioderInneholderJobberNormaltPerUke() {
+        final var enTime = Duration.ofHours(1);
+        final var builder = TestUtils.komplettBuilder();
+
+        var arbeid = arbeid(null, null, null);
+        assertFalse(alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
+                builder.arbeid(arbeid).build()
+        ));
+
+        arbeid = arbeid(enTime, null, null);
+        assertFalse(alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
+                builder.arbeid(arbeid).build()
+        ));
+
+        arbeid = arbeid(enTime, enTime, null);
+        assertFalse(alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
+                builder.arbeid(arbeid).build()
+        ));
+
+        arbeid = arbeid(enTime, null, enTime);
+        assertFalse(alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
+                builder.arbeid(arbeid).build()
+        ));
+
+        arbeid = arbeid(enTime, enTime, enTime);
+        assertTrue(alleArbeidstakerPerioderInneholderJobberNormaltPerUke(
+                builder.arbeid(arbeid).build()
+        ));
+    }
+
+    private Arbeid arbeid(
+            Duration jobberNormaltPerUkePeriode1,
+            Duration jobberNormaltPerUkePeriode2,
+            Duration jobberNormaltPerUkePeriode3) {
+        return Arbeid
+                .builder()
+                .arbeidstaker(Arbeidstaker
+                        .builder()
+                        .organisasjonsnummer(Organisasjonsnummer.of("88888888"))
+                        .periode(
+                                Periode.builder().fraOgMed(LocalDate.now()).tilOgMed(LocalDate.now().plusDays(3)).build(),
+                                Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
+                                        .skalJobbeProsent(BigDecimal.valueOf(40.00))
+                                        .jobberNormaltPerUke(jobberNormaltPerUkePeriode1)
+                                        .build())
+                        .periode(
+                                Periode.builder().fraOgMed(LocalDate.now().plusDays(6)).tilOgMed(LocalDate.now().plusDays(10)).build(),
+                                Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
+                                        .skalJobbeProsent(BigDecimal.valueOf(50.00))
+                                        .jobberNormaltPerUke(jobberNormaltPerUkePeriode2)
+                                        .build())
+                        .build()
+                )
+                .arbeidstaker(Arbeidstaker
+                        .builder()
+                        .norskIdentitetsnummer(NorskIdentitetsnummer.of("123"))
+                        .periode(
+                                Periode.builder().fraOgMed(LocalDate.now()).tilOgMed(LocalDate.now().plusDays(3)).build(),
+                                Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
+                                        .skalJobbeProsent(BigDecimal.valueOf(40.00))
+                                        .jobberNormaltPerUke(jobberNormaltPerUkePeriode3)
+                                        .build())
+                        .build()
+                )
+                .build();
     }
 }

--- a/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidatorTest.java
+++ b/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidatorTest.java
@@ -218,7 +218,7 @@ public class PleiepengerBarnSøknadValidatorTest {
                 ).build();
 
 
-        verifyIngenFeil(builder.arbeid(arbeid));
+        verifyHarFeil(builder.arbeid(arbeid));
     }
 
     @Test

--- a/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidatorTest.java
+++ b/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidatorTest.java
@@ -14,6 +14,7 @@ import java.util.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class PleiepengerBarnSøknadValidatorTest {
     private static final PleiepengerBarnSøknadValidator validator = new PleiepengerBarnSøknadValidator();
@@ -197,6 +198,66 @@ public class PleiepengerBarnSøknadValidatorTest {
                 )
                 .build();
         verifyIngenFeil(builder.arbeid(arbeid));
+    }
+
+    @Test
+    public void ArbeidstakerInfoUtenJobberNormaltPerUke() {
+        final PleiepengerBarnSøknad.Builder builder = TestUtils.komplettBuilder();
+        Arbeid arbeid = Arbeid
+                .builder()
+                .arbeidstaker(Arbeidstaker
+                        .builder()
+                        .organisasjonsnummer(Organisasjonsnummer.of("88888888"))
+                        .periode(
+                                Periode.builder().fraOgMed(LocalDate.now()).tilOgMed(LocalDate.now().plusDays(3)).build(),
+                                Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
+                                        .skalJobbeProsent(BigDecimal.valueOf(100.00))
+                                        .jobberNormaltPerUke(null)
+                                        .build()
+                        ).build()
+                ).build();
+
+        assertEquals(1,verifyHarFeil(builder.arbeid(arbeid)).size());
+    }
+
+    @Test
+    public void ArbeidstakerInfoMedJobberNormaltPerUkeOverEnUke() {
+        final PleiepengerBarnSøknad.Builder builder = TestUtils.komplettBuilder();
+        Arbeid arbeid = Arbeid
+                .builder()
+                .arbeidstaker(Arbeidstaker
+                        .builder()
+                        .organisasjonsnummer(Organisasjonsnummer.of("88888888"))
+                        .periode(
+                                Periode.builder().fraOgMed(LocalDate.now()).tilOgMed(LocalDate.now().plusDays(3)).build(),
+                                Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
+                                        .skalJobbeProsent(BigDecimal.valueOf(100.00))
+                                        .jobberNormaltPerUke(Duration.ofDays(7).plusSeconds(1))
+                                        .build()
+                        ).build()
+                ).build();
+
+        assertEquals(1,verifyHarFeil(builder.arbeid(arbeid)).size());
+    }
+
+    @Test
+    public void ArbeidstakerInfoMedJobberNormaltPerUkeSattTilNegativVerdi() {
+        final PleiepengerBarnSøknad.Builder builder = TestUtils.komplettBuilder();
+        Arbeid arbeid = Arbeid
+                .builder()
+                .arbeidstaker(Arbeidstaker
+                        .builder()
+                        .organisasjonsnummer(Organisasjonsnummer.of("88888888"))
+                        .periode(
+                                Periode.builder().fraOgMed(LocalDate.now()).tilOgMed(LocalDate.now().plusDays(3)).build(),
+                                Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
+                                        .skalJobbeProsent(BigDecimal.valueOf(100.00))
+                                        .jobberNormaltPerUke(Duration.ZERO.minusDays(1))
+                                        .build()
+                        ).build()
+                ).build();
+
+        assertEquals(1,verifyHarFeil(builder.arbeid(arbeid)).size());
     }
 
     private List<Feil> verifyHarFeil(PleiepengerBarnSøknad.Builder builder) {

--- a/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidatorTest.java
+++ b/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidatorTest.java
@@ -217,7 +217,8 @@ public class PleiepengerBarnSøknadValidatorTest {
                         ).build()
                 ).build();
 
-        assertEquals(1,verifyHarFeil(builder.arbeid(arbeid)).size());
+
+        verifyIngenFeil(builder.arbeid(arbeid));
     }
 
     @Test

--- a/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidatorTest.java
+++ b/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/PleiepengerBarnSøknadValidatorTest.java
@@ -217,8 +217,7 @@ public class PleiepengerBarnSøknadValidatorTest {
                         ).build()
                 ).build();
 
-
-        verifyHarFeil(builder.arbeid(arbeid));
+        assertEquals(1,verifyHarFeil(builder.arbeid(arbeid)).size());
     }
 
     @Test

--- a/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/TestUtils.java
+++ b/soknad-pleiepenger-barn/src/test/java/no/nav/k9/søknad/pleiepengerbarn/TestUtils.java
@@ -96,13 +96,19 @@ final class TestUtils {
                                 .organisasjonsnummer(Organisasjonsnummer.of("999999999"))
                                 .periode(
                                         Periode.builder().fraOgMed(LocalDate.parse("2018-10-10")).tilOgMed(LocalDate.parse("2018-12-29")).build(),
-                                        Arbeidstaker.ArbeidstakerPeriodeInfo.builder().skalJobbeProsent(BigDecimal.valueOf(50.25)).build())
+                                        Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
+                                                .skalJobbeProsent(BigDecimal.valueOf(50.25))
+                                                .jobberNormaltPerUke(Duration.parse("PT37H30M"))
+                                                .build())
                                 .build())
                         .arbeidstaker(Arbeidstaker.builder()
                                 .norskIdentitetsnummer(NorskIdentitetsnummer.of("29099012345"))
                                 .periode(
                                         Periode.builder().fraOgMed(LocalDate.parse("2018-11-10")).tilOgMed(LocalDate.parse("2018-12-29")).build(),
-                                        Arbeidstaker.ArbeidstakerPeriodeInfo.builder().skalJobbeProsent(BigDecimal.valueOf(20.00)).build())
+                                        Arbeidstaker.ArbeidstakerPeriodeInfo.builder()
+                                                .skalJobbeProsent(BigDecimal.valueOf(20.00))
+                                                .jobberNormaltPerUke(Duration.parse("PT10H"))
+                                                .build())
                                 .build())
                         .selvstendigNæringsdrivende(SelvstendigNæringsdrivende.builder()
                                 .periode(

--- a/soknad-pleiepenger-barn/src/test/resources/komplett-søknad.json
+++ b/soknad-pleiepenger-barn/src/test/resources/komplett-søknad.json
@@ -1,5 +1,5 @@
 {
-  "versjon" : "2.0.0",
+  "versjon" : "1.1.0",
   "søknadId": "1",
   "mottattDato" : "2019-10-20T07:15:36.124Z",
   "språk": "nb",

--- a/soknad-pleiepenger-barn/src/test/resources/komplett-søknad.json
+++ b/soknad-pleiepenger-barn/src/test/resources/komplett-søknad.json
@@ -1,5 +1,5 @@
 {
-  "versjon" : "1.1.0",
+  "versjon" : "2.0.0",
   "søknadId": "1",
   "mottattDato" : "2019-10-20T07:15:36.124Z",
   "språk": "nb",

--- a/soknad-pleiepenger-barn/src/test/resources/komplett-søknad.json
+++ b/soknad-pleiepenger-barn/src/test/resources/komplett-søknad.json
@@ -1,5 +1,5 @@
 {
-  "versjon" : "1.0.0",
+  "versjon" : "2.0.0",
   "søknadId": "1",
   "mottattDato" : "2019-10-20T07:15:36.124Z",
   "språk": "nb",
@@ -76,7 +76,8 @@
       "norskIdentitetsnummer": null,
       "perioder" : {
         "2018-10-10/2018-12-29": {
-          "skalJobbeProsent": 50.25
+          "skalJobbeProsent": 50.25,
+          "jobberNormaltPerUke": "PT37H30M"
         }
       }
     },{
@@ -84,7 +85,8 @@
       "norskIdentitetsnummer": "29099012345",
       "perioder" : {
         "2018-11-10/2018-12-29": {
-          "skalJobbeProsent": 20.00
+          "skalJobbeProsent": 20.00,
+          "jobberNormaltPerUke": "PT10H"
         }
       }
     }],


### PR DESCRIPTION
- Lagt til nytt optional felt `jobberNormaltPerUke`
- Kan ikke gjøre den required da det vil bli feil i Fordel i forhold til 1.0.0 og 1.1.0 søknader om hverandre.
- Fordel burde oppdateres til å støtte til og med versjon `1.1.0` av pleiepengesøknaden.
- Kun søknader som har `alleArbeidstakerPerioderInneholderJobberNormaltPerUke == true` kan gå inn til k9-sak (så det burde legges i Fordel i den berømte filtreringen som bl.a. disse infotrygdoppslagene befinner seg)