### PR TITLE
Frisinn utvidelser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	</modules>
 
 	<properties>
-		<revision>4.0.0</revision>
+		<revision>5.0.0</revision>
 		<sha1></sha1>
 		<changelist>-SNAPSHOT</changelist>
 		<java.version>11</java.version>

--- a/soknad-frisinn/README.MD
+++ b/soknad-frisinn/README.MD
@@ -1,45 +1,9 @@
 # Søknad for Frisinn (FRIlanser og Selvstendig næringsdrivendes INNtektskompensasjon)
 
-## Eksempel søknad (fra test case)
+## Changelog
+### 2.0.0
+- Fjernet `inntekter.frilanser.erNyetablert`
+- Lagt til `inntekter.arbeidstaker` 
 
-```
-{
-  "søknadId" : "100-abc",
-  "søknadsperiode" : "2020-04-01/2020-04-30",
-  "versjon" : "1.0.0",
-  "mottattDato" : "2020-04-20T07:15:36.124Z",
-  "søker" : {
-    "norskIdentitetsnummer" : "12345678901"
-  },
-  "inntekter" : {
-    "frilanser" : {
-      "inntekterSøknadsperiode" : {
-        "2020-04-01/2020-04-21" : {
-          "beløp" : "100000.00"
-        }
-      }
-    },
-    "selvstendig" : {
-      "inntekterFør" : {
-        "../2020-02-21" : {
-          "beløp" : "100000.00"
-        },
-        "2020-02-22/2020-03-12" : {
-          "beløp" : "100000.00"
-        }
-      },
-      "inntekterSøknadsperiode" : {
-        "2020-04-05/2020-04-16" : {
-          "beløp" : "0.00"
-        },
-        "2020-04-17/2020-04-30" : {
-          "beløp" : "10000.00"
-        }
-      }
-    }
-  },
-  "språk" : "nb"
-}
-
-
-```
+## Eksempelsøknader
+Se eksempler i [testresource](https://github.com/navikt/k9-format/tree/master/soknad-frisinn/src/test/resources)

--- a/soknad-frisinn/src/main/java/no/nav/k9/søknad/frisinn/Arbeidstaker.java
+++ b/soknad-frisinn/src/main/java/no/nav/k9/søknad/frisinn/Arbeidstaker.java
@@ -17,37 +17,24 @@ import no.nav.k9.søknad.felles.Periode;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
-public class Frilanser {
+public class Arbeidstaker {
 
     /**
-     * Inntekter i periode som skal kompenseres. Periode må være innenfor søknadsperiode. Hvis ingen inntekt i periode som kompenseres, sett
-     * inntekt = 0
+     * Inntekter i periode som arbeidstaker.
      */
     @JsonProperty(value = "inntekterSøknadsperiode")
     @Valid
     private NavigableMap<Periode, PeriodeInntekt> inntekterSøknadsperiode;
 
-    /**
-     * Hvorvidt bruker ønsker inntekter i samme periode som angitt inntekter i søknadsperiode kompensert mot tidligere opptjent
-     * beregningsgrunnlag.
-     */
-    @JsonProperty(value = "søkerKompensasjon")
-    private final boolean søkerKompensasjon;
-    
+
     @JsonCreator
-    public Frilanser(@JsonProperty(value = "inntekterSøknadsperiode") Map<Periode, PeriodeInntekt> inntekterSøknadsperiode,
-                     @JsonProperty(value = "søkerKompensasjon") Boolean søkerKompensasjon) {
+    public Arbeidstaker(@JsonProperty(value = "inntekterSøknadsperiode") Map<Periode, PeriodeInntekt> inntekterSøknadsperiode) {
         this.inntekterSøknadsperiode = (inntekterSøknadsperiode == null) ? Collections.emptyNavigableMap()
-            : Collections.unmodifiableNavigableMap(new TreeMap<>(inntekterSøknadsperiode));
-        this.søkerKompensasjon = søkerKompensasjon == null ? true : søkerKompensasjon;
+                : Collections.unmodifiableNavigableMap(new TreeMap<>(inntekterSøknadsperiode));
     }
 
     public NavigableMap<Periode, PeriodeInntekt> getInntekterSøknadsperiode() {
         return inntekterSøknadsperiode;
-    }
-
-    public boolean getSøkerKompensasjon() {
-        return søkerKompensasjon;
     }
 
     public static Builder builder() {
@@ -61,10 +48,9 @@ public class Frilanser {
             return new Periode(inntekterSøknadsperiode.firstKey().fraOgMed, inntekterSøknadsperiode.lastKey().tilOgMed);
         }
     }
-    
+
     public static final class Builder {
         private Map<Periode, PeriodeInntekt> inntekterSøknadsperiode = new LinkedHashMap<>();
-        private boolean søkerKompensasjon = true;
 
         private Builder() {
         }
@@ -74,13 +60,8 @@ public class Frilanser {
             return this;
         }
 
-        public Builder søkerKompensasjon(boolean søkerKompensasjon) {
-            this.søkerKompensasjon = søkerKompensasjon;
-            return this;
-        }
-
-        public Frilanser build() {
-            return new Frilanser(inntekterSøknadsperiode, søkerKompensasjon);
+        public Arbeidstaker build() {
+            return new Arbeidstaker(inntekterSøknadsperiode);
         }
     }
 

--- a/soknad-frisinn/src/main/java/no/nav/k9/søknad/frisinn/FrisinnSøknad.java
+++ b/soknad-frisinn/src/main/java/no/nav/k9/søknad/frisinn/FrisinnSøknad.java
@@ -82,15 +82,25 @@ public class FrisinnSøknad {
         if (inntekter.getSelvstendig() != null) {
             validerSøknadInntektPeriode("selvstendig", inntekter.getSelvstendig().getMaksSøknadsperiode());
         }
+        if (inntekter.getArbeidstaker() != null) {
+            var maks = inntekter.getArbeidstaker().getMaksSøknadsperiode();
+            if (maks != null) {
+                validerInnenforSøknadsperiode("arbeidstaker", maks);
+            }
+        }
     }
 
     private void validerSøknadInntektPeriode(String tekst, Periode inntektPeriode) {
         if(inntektPeriode==null) {
             throw new IllegalArgumentException("Mangler inntektperiode for " + tekst);
         }
+        validerInnenforSøknadsperiode(tekst, inntektPeriode);
+    }
+
+    private void validerInnenforSøknadsperiode(String tekst, Periode inntektPeriode) {
         if (!søknadsperiode.inneholder(inntektPeriode)) {
             throw new IllegalArgumentException(
-                "Inntektperiode [" + inntektPeriode + "] må være innenfor søknadsperiode [" + søknadsperiode + " for " + tekst + "]");
+                    "Inntektperiode [" + inntektPeriode + "] må være innenfor søknadsperiode [" + søknadsperiode + " for " + tekst + "]");
         }
     }
 
@@ -151,7 +161,7 @@ public class FrisinnSøknad {
     public static final class Builder {
         private static final ValidatorFactory VALIDATOR_FACTORY = Validation.buildDefaultValidatorFactory();
 
-        private static final Versjon versjon = Versjon.of("1.0.0");
+        private static final Versjon versjon = Versjon.of("2.0.0");
 
         private SøknadId søknadId;
 

--- a/soknad-frisinn/src/main/java/no/nav/k9/søknad/frisinn/Inntekter.java
+++ b/soknad-frisinn/src/main/java/no/nav/k9/søknad/frisinn/Inntekter.java
@@ -23,14 +23,21 @@ public class Inntekter {
     @Valid
     private SelvstendigNæringsdrivende selvstendig;
 
+    @JsonInclude(value = Include.NON_EMPTY)
+    @JsonProperty(value = "arbeidstaker")
+    @Valid
+    private Arbeidstaker arbeidstaker;
+
     @JsonCreator
     public Inntekter(@JsonProperty(value = "frilanser") Frilanser frilanser,
-                     @JsonProperty(value = "selvstendig") SelvstendigNæringsdrivende selvstendig) {
+                     @JsonProperty(value = "selvstendig") SelvstendigNæringsdrivende selvstendig,
+                     @JsonProperty(value = "arbeidstaker") Arbeidstaker arbeidstaker) {
         if (frilanser == null && selvstendig == null) {
             throw new IllegalArgumentException("Må spesifisere enten frilanser eller selvstendig næringsdrivende");
         }
         this.frilanser = frilanser;
         this.selvstendig = selvstendig;
+        this.arbeidstaker = arbeidstaker;
     }
 
     public Frilanser getFrilanser() {
@@ -40,4 +47,9 @@ public class Inntekter {
     public SelvstendigNæringsdrivende getSelvstendig() {
         return selvstendig;
     }
+
+    public Arbeidstaker getArbeidstaker() {
+        return arbeidstaker;
+    }
+
 }

--- a/soknad-frisinn/src/test/resources/1.0.0.json
+++ b/soknad-frisinn/src/test/resources/1.0.0.json
@@ -1,0 +1,36 @@
+{
+  "søknadId": "d6c4afe3-41d1-4294-bc37-8557c1f33b76",
+  "søknadsperiode": "2020-03-14/2020-04-30",
+  "versjon": "1.0.0",
+  "mottattDato": "2020-05-18T08:42:33.125Z",
+  "søker": {
+    "norskIdentitetsnummer": "2"
+  },
+  "inntekter": {
+    "frilanser": {
+      "inntekterSøknadsperiode": {
+        "2020-03-30/2020-04-30": {
+          "beløp": "6000"
+        }
+      },
+      "søkerKompensasjon": true,
+      "erNyetablert": true
+    },
+    "selvstendig": {
+      "inntekterFør": {
+        "2020-02-29/2020-02-29": {
+          "beløp": "50000"
+        }
+      },
+      "inntekterSøknadsperiode": {
+        "2020-04-14/2020-04-30": {
+          "beløp": "5000"
+        }
+      },
+      "søkerKompensasjon": true,
+      "regnskapsførerNavn": "Ola S. Nordmann's regnskaps''byrå",
+      "regnskapsførerTlf": "222 25 555"
+    }
+  },
+  "språk": "nb"
+}

--- a/soknad-frisinn/src/test/resources/2.0.0.json
+++ b/soknad-frisinn/src/test/resources/2.0.0.json
@@ -1,0 +1,42 @@
+{
+  "søknadId": "d6c4afe3-41d1-4294-bc37-8557c1f33b76",
+  "søknadsperiode": "2020-03-14/2020-04-30",
+  "versjon": "2.0.0",
+  "mottattDato": "2020-05-18T08:42:33.125Z",
+  "søker": {
+    "norskIdentitetsnummer": "2"
+  },
+  "inntekter": {
+    "arbeidstaker": {
+      "inntekterSøknadsperiode": {
+        "2020-03-30/2020-04-30": {
+          "beløp": "6005"
+        }
+      }
+    },
+    "frilanser": {
+      "inntekterSøknadsperiode": {
+        "2020-03-30/2020-04-30": {
+          "beløp": "6000"
+        }
+      },
+      "søkerKompensasjon": true
+    },
+    "selvstendig": {
+      "inntekterFør": {
+        "2020-02-29/2020-02-29": {
+          "beløp": "50000"
+        }
+      },
+      "inntekterSøknadsperiode": {
+        "2020-04-14/2020-04-30": {
+          "beløp": "5000"
+        }
+      },
+      "søkerKompensasjon": true,
+      "regnskapsførerNavn": "Ola S. Nordmann's regnskaps''byrå",
+      "regnskapsførerTlf": "222 25 555"
+    }
+  },
+  "språk": "nb"
+}


### PR DESCRIPTION
- Fjernet `inntekter.frilanser.erNyetablert`
- Lagt til `inntekter.arbeidstaker` - Skal ikke oppgis èn for frilanser-periode og en for selvstendig-perioden, men en samlet for søknaden. Om man søker begge deler med  to forskjellige perioder vil det være den overordnede perioden som settes her.
- Tester  for å se om vi kan bruke samme format også for påfølgende søknader (de som har søkt frisinn  en tidligere periode)