### PR TITLE
Legger til jsonsubtypes for interface ytelse

### DIFF
--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/Ytelse.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/Ytelse.java
@@ -4,13 +4,21 @@ import java.util.List;
 
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import no.nav.k9.søknad.felles.type.Periode;
 import no.nav.k9.søknad.felles.type.Person;
 
+import no.nav.k9.søknad.ytelse.omsorgspenger.v1.OmsorgspengerUtbetaling;
+import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarn;
+
 @Valid
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(value = {
+        @JsonSubTypes.Type(name = "OMP_UT", value = OmsorgspengerUtbetaling.class),
+        @JsonSubTypes.Type(name = "PLEIEPENGER_SYKT_BARN", value = PleiepengerSyktBarn.class),
+})
 public interface Ytelse {
 
     String OMSORGSPENGER_UTBETALING = "OMP_UT";


### PR DESCRIPTION
Dette for å løse følgende feil ved parsing:
com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'OMP_UT' as a subtype of `no.nav.k9.søknad.ytelse.Ytelse`: known type ids = [] (for POJO property 'ytelse')