### PR TITLE
Fikser feilkode ved mapping til Feil i PleiepengerSyktBarnValidator.

### DIFF
--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/psb/v1/PleiepengerSyktBarnValidator.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/psb/v1/PleiepengerSyktBarnValidator.java
@@ -53,8 +53,8 @@ public class PleiepengerSyktBarnValidator extends YtelseValidator {
     private Feil toFeil(ConstraintViolation<PleiepengerSyktBarn> constraintViolation) {
         return new Feil(
                 constraintViolation.getPropertyPath().toString(),
-                constraintViolation.getMessage() + " ConstraintViolation ",
-                constraintViolation.getMessageTemplate());
+                PÅKREVD,
+                constraintViolation.getMessage());
     }
 
     private void validerSøknadsperiode(Periode søknadsperiode, List<Feil> feil) {


### PR DESCRIPTION
constraintViolation.getMessageTemplate() returnerer "${validatedMessage}" dersom felt/metode er valideringsannotasjon med med message="${validatedValue}".

constraintViolation.getMessage() returnerer selve meldingen man forventer å lese.