### PR TITLE
Fix: OMP Validering av periode som ikke er satt ordentlig

### DIFF
--- a/soknad/src/main/java/no/nav/k9/søknad/felles/fravær/FraværPeriode.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/felles/fravær/FraværPeriode.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.validation.Valid;
+import javax.validation.constraints.AssertFalse;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -74,6 +75,16 @@ public class FraværPeriode implements Comparable<FraværPeriode> {
         this.aktivitetFravær = aktivitetFravær.stream().sorted().toList(); //sorterer for å få enklere equals og hashcode
         this.arbeidsgiverOrgNr = arbeidsgiverOrgNr;
         this.arbeidsforholdId = arbeidsforholdId;
+    }
+
+    @AssertFalse(message = "Mangler fra-og-med-dato for perioden")
+    boolean isPeriodeManglerFom(){
+        return periode != null && periode.getFraOgMed() == null;
+    }
+
+    @AssertFalse(message = "Mangler til-og-med-dato for perioden")
+    boolean isPeriodeManglerTom(){
+        return periode != null && periode.getTilOgMed() == null;
     }
 
     public FraværPeriode medPeriode(Periode periode) {

--- a/soknad/src/main/java/no/nav/k9/søknad/felles/fravær/FraværPeriode.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/felles/fravær/FraværPeriode.java
@@ -87,6 +87,11 @@ public class FraværPeriode implements Comparable<FraværPeriode> {
         return periode != null && periode.getTilOgMed() == null;
     }
 
+    @AssertFalse(message = "Til-og-med-dato er før fra-og-med-dato for perioden")
+    boolean isPeriodeTomFørFom(){
+        return periode != null && periode.getTilOgMed() != null && periode.getFraOgMed() != null && periode.getTilOgMed().isBefore(periode.getFraOgMed());
+    }
+
     public FraværPeriode medPeriode(Periode periode) {
         this.periode = periode;
         return this;

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/v1/OmsorgspengerUtbetalingValidator.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/v1/OmsorgspengerUtbetalingValidator.java
@@ -57,7 +57,7 @@ public class OmsorgspengerUtbetalingValidator extends YtelseValidator {
     }
 
     private List<Feil> validerPeriodeInnenforEttÅr(OmsorgspengerUtbetaling ytelse) {
-        if (ytelse.getFraværsperioder().stream().anyMatch(OmsorgspengerUtbetalingValidator::erPeriodeUdefinert)) {
+        if (ytelse.getFraværsperioder().stream().anyMatch(OmsorgspengerUtbetalingValidator::erPeriodeUgyldig)) {
             //avbryter her for å unngå NPE i koden under når periode ikke er satt, eller ikke er satt ordentlig
             //nødvendig siden validatoren brukes mens søknaden bygges i k9-punsj, og søknad vil således være ukomplett underveis
             //periode valideres andre steder uansett
@@ -240,7 +240,7 @@ public class OmsorgspengerUtbetalingValidator extends YtelseValidator {
         Map<Aktivitet, Set<Periode>> unikePerioderPrAktivitet = new HashMap<>();
         int index = 0;
         for (FraværPeriode fraværPeriode : fraværPerioder) {
-            if (erPeriodeUdefinert(fraværPeriode)){
+            if (erPeriodeUgyldig(fraværPeriode)){
                 //avbryter her for å unngå NPE i koden under når periode ikke er satt, eller ikke er satt ordentlig
                 //nødvendig siden validatoren brukes mens søknaden bygges i k9-punsj, og søknad vil således være ukomplett underveis
                 //periode valideres andre steder uansett
@@ -274,9 +274,9 @@ public class OmsorgspengerUtbetalingValidator extends YtelseValidator {
         return feil;
     }
 
-    private static boolean erPeriodeUdefinert(FraværPeriode fraværPeriode){
+    private static boolean erPeriodeUgyldig(FraværPeriode fraværPeriode){
         Periode periode = fraværPeriode.getPeriode();
-        return periode == null || periode.getFraOgMed() == null || periode.getTilOgMed() == null;
+        return periode == null || periode.getFraOgMed() == null || periode.getTilOgMed() == null || periode.getTilOgMed().isBefore(periode.getFraOgMed());
     }
 
 

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/v1/OmsorgspengerUtbetalingValidator.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/v1/OmsorgspengerUtbetalingValidator.java
@@ -57,15 +57,20 @@ public class OmsorgspengerUtbetalingValidator extends YtelseValidator {
     }
 
     private List<Feil> validerPeriodeInnenforEttÅr(OmsorgspengerUtbetaling ytelse) {
-        List<Feil> feil = new ArrayList<>();
+        if (ytelse.getFraværsperioder().stream().anyMatch(OmsorgspengerUtbetalingValidator::erPeriodeUdefinert)) {
+            //avbryter her for å unngå NPE i koden under når periode ikke er satt, eller ikke er satt ordentlig
+            //nødvendig siden validatoren brukes mens søknaden bygges i k9-punsj, og søknad vil således være ukomplett underveis
+            //periode valideres andre steder uansett
+            return List.of();
+        }
         var søknadsperiode = ytelse.getSøknadsperiode();
         var yearMin = søknadsperiode.getFraOgMed().getYear();
         var yearMax = søknadsperiode.getTilOgMed().getYear();
 
         if (yearMin != yearMax) {
-            feil.add(new Feil("fraværsperioder", "perioderOverFlereÅr", "Perioder kan ikke overstige ett år"));
+            return List.of(new Feil("fraværsperioder", "perioderOverFlereÅr", "Perioder kan ikke overstige ett år"));
         }
-        return feil;
+        return List.of();
     }
 
     private List<Feil> validerAktivitet(OmsorgspengerUtbetaling ytelse) {
@@ -235,6 +240,12 @@ public class OmsorgspengerUtbetalingValidator extends YtelseValidator {
         Map<Aktivitet, Set<Periode>> unikePerioderPrAktivitet = new HashMap<>();
         int index = 0;
         for (FraværPeriode fraværPeriode : fraværPerioder) {
+            if (erPeriodeUdefinert(fraværPeriode)){
+                //avbryter her for å unngå NPE i koden under når periode ikke er satt, eller ikke er satt ordentlig
+                //nødvendig siden validatoren brukes mens søknaden bygges i k9-punsj, og søknad vil således være ukomplett underveis
+                //periode valideres andre steder uansett
+                continue;
+            }
             for (AktivitetFravær aktivitetType : fraværPeriode.getAktivitetFravær()) {
                 Aktivitet aktivitet = new Aktivitet(aktivitetType, fraværPeriode.getArbeidsgiverOrgNr());
                 Set<Periode> unikePerioder = unikePerioderPrAktivitet.computeIfAbsent(aktivitet, k -> new HashSet<>());
@@ -262,6 +273,12 @@ public class OmsorgspengerUtbetalingValidator extends YtelseValidator {
         }
         return feil;
     }
+
+    private static boolean erPeriodeUdefinert(FraværPeriode fraværPeriode){
+        Periode periode = fraværPeriode.getPeriode();
+        return periode == null || periode.getFraOgMed() == null || periode.getTilOgMed() == null;
+    }
+
 
     private List<Feil> validerOverlappendePerioderKorrigerIm(List<FraværPeriode> fraværPerioder) {
         List<Feil> feil = new ArrayList<>();

--- a/soknad/src/test/java/no/nav/k9/søknad/ytelse/omsorgspenger/v1/OmsorgspengerUtbetalingValidatorTest.java
+++ b/soknad/src/test/java/no/nav/k9/søknad/ytelse/omsorgspenger/v1/OmsorgspengerUtbetalingValidatorTest.java
@@ -127,21 +127,24 @@ class OmsorgspengerUtbetalingValidatorTest {
         Periode periode1 = new Periode(null, null);
         Periode periode2 = new Periode(null, LocalDate.now());
         Periode periode3 = new Periode(LocalDate.now(), null);
+        Periode periode4 = new Periode(LocalDate.now(), LocalDate.now().minusDays(1));
         OmsorgspengerUtbetaling ytelse = byggOmsorgspengerUtbetalingSøknadBruker(
                 lagSøknadsperiode(orgnr1, periode, null),
                 lagSøknadsperiode(orgnr1, periode1, null),
                 lagSøknadsperiode(orgnr1, periode2, null),
-                lagSøknadsperiode(orgnr1, periode3, null)
+                lagSøknadsperiode(orgnr1, periode3, null),
+                lagSøknadsperiode(orgnr1, periode4, null)
         );
 
         List<Feil> feil = lagSøknadOgValider(ytelse);
 
-        assertThat(feil).hasSize(5);
+        assertThat(feil).hasSize(6);
         feilInneholder(feil, "ytelse.fraværsperioder['0'].periode", "nullFeil");
         feilInneholder(feil, "ytelse.fraværsperioder['1'].periodeManglerFom", "påkrevd");
         feilInneholder(feil, "ytelse.fraværsperioder['1'].periodeManglerTom", "påkrevd");
         feilInneholder(feil, "ytelse.fraværsperioder['2'].periodeManglerFom", "påkrevd");
         feilInneholder(feil, "ytelse.fraværsperioder['3'].periodeManglerTom", "påkrevd");
+        feilInneholder(feil, "ytelse.fraværsperioder['4'].periodeTomFørFom", "påkrevd");
     }
 
     @Test


### PR DESCRIPTION
* Fix: validerer at periode er satt ordentlig i OMP fraværsperioe
* Fix: Unngår NPE i validering når periode ikke er satt ordentlig
* bruker søknadvalidator isdf ytelsevalidator i test for OMP