### PR TITLE
Utvider søknad ytelser med DataBruktTilUtledning.

### DIFF
--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/DataBruktTilUtledning.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/DataBruktTilUtledning.java
@@ -1,0 +1,126 @@
+package no.nav.k9.søknad.ytelse;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import no.nav.k9.søknad.JsonUtils;
+
+import javax.validation.Valid;
+import javax.validation.constraints.AssertTrue;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * <p>Klassen representerer tilleggsdata som har verdi som dokumentasjon.
+ * Disse dataene blir bevart for nåværende og fremtidige formål og er ment for sikker oppbevaring i NAVs arkivsystem.</p>
+ *
+ * <p>Disse feltene spiller en avgjørende rolle i å sikre at dataene er tilgjengelige, gjenfinnbare og pålitelige, samtidig som de beholder sin bevisverdi.
+ * Det brukes primært til å lagre data som genereres eller håndteres gjennom Dialog- og samhandlingssystemer.</p>
+ *
+ * <p>Vær oppmerksom på at all data som lagres her, skal behandles som arkivdokumentasjon, og bør derfor håndteres med tilsvarende forsiktighet og sikkerhetsprosedyrer.</p>
+ */
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DataBruktTilUtledning {
+
+    /**
+     * Brukes for å bekrefte at bruker har forstått rettigheter og plikter.
+     */
+    @JsonProperty(value = "harForståttRettigheterOgPlikter", required = true)
+    @Valid
+    @AssertTrue(message = "Må ha forstått rettigheter og plikter må være true")
+    private Boolean harForståttRettigheterOgPlikter;
+
+    /**
+     * Brukes for å bekrefte at bruker har bekreftet opplysninger.
+     */
+    @JsonProperty(value = "harBekreftetOpplysninger", required = true)
+    @Valid
+    @AssertTrue(message = "Må ha bekreftet opplysninger må være true")
+    private Boolean harBekreftetOpplysninger;
+
+
+    /**
+     * Brukes for å kunne spore opprinnelig commit SHA fra søknadsdialog.
+     */
+    @JsonProperty(value = "soknadDialogCommitSha")
+    @Valid
+    private String soknadDialogCommitSha;
+
+
+    /**
+     * <p>Feltet "annetData" representerer tilleggsdata som ikke er direkte spesifisert
+     * av de andre feltene i denne klassen. Dette kan inkludere alle supplerende
+     * eller hjelpedata som er knyttet til en instans av denne klassen.</p>
+     *
+     * <p>Det brukes primært til å lagre avledet data generert under søknadsdialogprosessen.
+     * Formålet med dette feltet er ikke å påvirke klassens primære funksjon, men å assistere
+     * i å gi ekstra kontekst eller metadata der det er nødvendig.</p>
+     *
+     * <p>Merk at denne dataen skal brukes med forsiktighet, ettersom den ikke er direkte kontrollert
+     * av klassens struktur og ikke er underlagt de samme valideringene eller sjekkene som andre felt.</p>
+     */
+    @JsonProperty("annetData")
+    private Map<String, Object> annetData;
+
+    public DataBruktTilUtledning() {
+        this.annetData = new HashMap<>();
+    }
+
+    public Boolean getHarForståttRettigheterOgPlikter() {
+        return harForståttRettigheterOgPlikter;
+    }
+
+    public DataBruktTilUtledning medHarForståttRettigheterOgPlikter(Boolean harForståttRettigheterOgPlikter) {
+        this.harForståttRettigheterOgPlikter = harForståttRettigheterOgPlikter;
+        return this;
+    }
+
+    public Boolean getHarBekreftetOpplysninger() {
+        return harBekreftetOpplysninger;
+    }
+
+    public DataBruktTilUtledning medHarBekreftetOpplysninger(Boolean harBekreftetOpplysninger) {
+        this.harBekreftetOpplysninger = harBekreftetOpplysninger;
+        return this;
+    }
+
+    public String getSoknadDialogCommitSha() {
+        return this.soknadDialogCommitSha;
+    }
+
+    public DataBruktTilUtledning medSoknadDialogCommitSha(String soknadDialogCommitSha) {
+        this.soknadDialogCommitSha = soknadDialogCommitSha;
+        return this;
+    }
+
+    public Map<String, Object> getAnnetData() {
+        return this.annetData;
+    }
+
+    public DataBruktTilUtledning setAnnetData(Map<String, Object> annetData) {
+        this.annetData = annetData;
+        return this;
+    }
+
+    public DataBruktTilUtledning medData(String key, Object value) {
+        this.annetData.put(key, value);
+        return this;
+    }
+
+    /**
+     * Returnerer en JSON-representasjon av denne klassen eller toString fra superklassen.
+     * Hvis serialisering feiler, returneres toString fra superklassen.
+     * @return JSON-representasjon av denne klassen.
+     */
+    @Override
+    public String toString() {
+        try {
+            return JsonUtils.toString(this);
+        } catch (Exception e) {
+            // hvis serialisering feiler, returner toString fra superklassen.
+            return super.toString();
+        }
+    }
+}

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/DataBruktTilUtledning.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/DataBruktTilUtledning.java
@@ -1,6 +1,7 @@
 package no.nav.k9.søknad.ytelse;
 
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import no.nav.k9.søknad.JsonUtils;
@@ -22,6 +23,7 @@ import java.util.Map;
  */
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
 public class DataBruktTilUtledning {
 
     /**

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/Ytelse.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/Ytelse.java
@@ -55,6 +55,12 @@ public interface Ytelse {
     YtelseValidator getValidator(Versjon versjon);
 
     /**
+     * Data brukt til utledning av ytelse.
+     */
+    DataBruktTilUtledning getDataBruktTilUtledning();
+    Ytelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning);
+
+    /**
      * @return andre berørte, kjente identifiserte personer (enn søker) - f.eks. barn, ektefelle, verge etc. som er involveres i denne saken.
      */
     List<Person> getBerørtePersoner();

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/olp/v1/Opplæringspenger.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/olp/v1/Opplæringspenger.java
@@ -23,10 +23,10 @@ import no.nav.k9.søknad.felles.personopplysninger.Bosteder;
 import no.nav.k9.søknad.felles.personopplysninger.Utenlandsopphold;
 import no.nav.k9.søknad.felles.type.Periode;
 import no.nav.k9.søknad.felles.type.Person;
+import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 import no.nav.k9.søknad.ytelse.Ytelse;
 import no.nav.k9.søknad.ytelse.YtelseValidator;
 import no.nav.k9.søknad.ytelse.olp.v1.kurs.Kurs;
-import no.nav.k9.søknad.ytelse.psb.v1.DataBruktTilUtledning;
 import no.nav.k9.søknad.ytelse.psb.v1.LovbestemtFerie;
 import no.nav.k9.søknad.ytelse.psb.v1.Omsorg;
 import no.nav.k9.søknad.ytelse.psb.v1.Uttak;
@@ -259,5 +259,16 @@ public class Opplæringspenger implements Ytelse {
     @Override
     public YtelseValidator getValidator(Versjon versjon) {
         return new OpplæringspengerYtelseValidator();
+    }
+
+    @Override
+    public DataBruktTilUtledning getDataBruktTilUtledning() {
+        return this.dataBruktTilUtledning;
+    }
+
+    @Override
+    public Ytelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
+        this.dataBruktTilUtledning = dataBruktTilUtledning;
+        return this;
     }
 }

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/utvidetrett/v1/OmsorgspengerAleneOmsorg.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/utvidetrett/v1/OmsorgspengerAleneOmsorg.java
@@ -1,24 +1,22 @@
 package no.nav.k9.søknad.ytelse.omsorgspenger.utvidetrett.v1;
 
-import java.util.List;
-import java.util.Objects;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import no.nav.k9.søknad.felles.Feil;
 import no.nav.k9.søknad.felles.Versjon;
 import no.nav.k9.søknad.felles.personopplysninger.Barn;
 import no.nav.k9.søknad.felles.type.Periode;
 import no.nav.k9.søknad.felles.type.Person;
+import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 import no.nav.k9.søknad.ytelse.Ytelse;
 import no.nav.k9.søknad.ytelse.YtelseValidator;
-import no.nav.k9.søknad.ytelse.omsorgspenger.v1.OmsorgspengerUtbetalingSøknadValidator;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
@@ -35,6 +33,10 @@ public class OmsorgspengerAleneOmsorg implements OmsorgspengerUtvidetRett {
     @JsonProperty(value = "periode")
     @NotNull
     private Periode periode;
+
+    @JsonProperty(value = "dataBruktTilUtledning")
+    @Valid
+    private DataBruktTilUtledning dataBruktTilUtledning;
 
     public OmsorgspengerAleneOmsorg() {
     }
@@ -54,6 +56,17 @@ public class OmsorgspengerAleneOmsorg implements OmsorgspengerUtvidetRett {
     @Override
     public YtelseValidator getValidator(Versjon versjon) {
         return new MinValidator();
+    }
+
+    @Override
+    public DataBruktTilUtledning getDataBruktTilUtledning() {
+        return this.dataBruktTilUtledning;
+    }
+
+    @Override
+    public Ytelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
+        this.dataBruktTilUtledning = dataBruktTilUtledning;
+        return this;
     }
 
     @Override

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/utvidetrett/v1/OmsorgspengerKroniskSyktBarn.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/utvidetrett/v1/OmsorgspengerKroniskSyktBarn.java
@@ -1,25 +1,22 @@
 package no.nav.k9.søknad.ytelse.omsorgspenger.utvidetrett.v1;
 
-import java.util.List;
-import java.util.Objects;
-
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import no.nav.k9.søknad.felles.Feil;
 import no.nav.k9.søknad.felles.Versjon;
 import no.nav.k9.søknad.felles.personopplysninger.Barn;
-import no.nav.k9.søknad.felles.type.Person;
 import no.nav.k9.søknad.felles.type.Periode;
+import no.nav.k9.søknad.felles.type.Person;
+import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 import no.nav.k9.søknad.ytelse.Ytelse;
 import no.nav.k9.søknad.ytelse.YtelseValidator;
-import no.nav.k9.søknad.ytelse.omsorgspenger.v1.OmsorgspengerUtbetalingSøknadValidator;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
@@ -34,6 +31,10 @@ public class OmsorgspengerKroniskSyktBarn implements OmsorgspengerUtvidetRett {
     @Valid
     @NotNull
     private Boolean kroniskEllerFunksjonshemming;
+
+    @JsonProperty(value = "dataBruktTilUtledning")
+    @Valid
+    private DataBruktTilUtledning dataBruktTilUtledning;
 
     public OmsorgspengerKroniskSyktBarn() {
     }
@@ -68,6 +69,18 @@ public class OmsorgspengerKroniskSyktBarn implements OmsorgspengerUtvidetRett {
     public YtelseValidator getValidator(Versjon versjon) {
         return new MinValidator();
     }
+
+    @Override
+    public DataBruktTilUtledning getDataBruktTilUtledning() {
+        return this.dataBruktTilUtledning;
+    }
+
+    @Override
+    public Ytelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
+        this.medDataBruktTilUtledning(dataBruktTilUtledning);
+        return this;
+    }
+
 
     @Override
     public List<Person> getBerørtePersoner() {

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/utvidetrett/v1/OmsorgspengerMidlertidigAlene.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/utvidetrett/v1/OmsorgspengerMidlertidigAlene.java
@@ -23,6 +23,7 @@ import no.nav.k9.søknad.felles.Versjon;
 import no.nav.k9.søknad.felles.personopplysninger.Barn;
 import no.nav.k9.søknad.felles.type.Periode;
 import no.nav.k9.søknad.felles.type.Person;
+import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 import no.nav.k9.søknad.ytelse.Ytelse;
 import no.nav.k9.søknad.ytelse.YtelseValidator;
 
@@ -43,6 +44,10 @@ public class OmsorgspengerMidlertidigAlene implements OmsorgspengerUtvidetRett {
     @JsonProperty(value = "begrunnelse")
     @Size(max = 30000)
     private String begrunnelse;
+
+    @JsonProperty(value = "dataBruktTilUtledning")
+    @Valid
+    private DataBruktTilUtledning dataBruktTilUtledning;
 
     public OmsorgspengerMidlertidigAlene() {
     }
@@ -82,6 +87,17 @@ public class OmsorgspengerMidlertidigAlene implements OmsorgspengerUtvidetRett {
     @Override
     public YtelseValidator getValidator(Versjon versjon) {
         return new MinValidator();
+    }
+
+    @Override
+    public DataBruktTilUtledning getDataBruktTilUtledning() {
+        return this.dataBruktTilUtledning;
+    }
+
+    @Override
+    public Ytelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
+        this.dataBruktTilUtledning = dataBruktTilUtledning;
+        return this;
     }
 
     public String getBegrunnelse() {

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/v1/OmsorgspengerUtbetaling.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/omsorgspenger/v1/OmsorgspengerUtbetaling.java
@@ -21,6 +21,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Bosteder;
 import no.nav.k9.søknad.felles.personopplysninger.Utenlandsopphold;
 import no.nav.k9.søknad.felles.type.Periode;
 import no.nav.k9.søknad.felles.type.Person;
+import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 import no.nav.k9.søknad.ytelse.Ytelse;
 import no.nav.k9.søknad.ytelse.YtelseValidator;
 
@@ -52,6 +53,10 @@ public class OmsorgspengerUtbetaling implements Ytelse {
     @Valid
     @JsonProperty(value = "fraværsperioderKorrigeringIm")
     private List<FraværPeriode> fraværsperioderKorrigeringIm;
+
+    @JsonProperty(value = "dataBruktTilUtledning")
+    @Valid
+    private DataBruktTilUtledning dataBruktTilUtledning;
 
     public OmsorgspengerUtbetaling() {
         //
@@ -137,6 +142,17 @@ public class OmsorgspengerUtbetaling implements Ytelse {
     @Override
     public YtelseValidator getValidator(Versjon versjon) {
         return new OmsorgspengerUtbetalingValidator(versjon);
+    }
+
+    @Override
+    public DataBruktTilUtledning getDataBruktTilUtledning() {
+        return this.dataBruktTilUtledning;
+    }
+
+    @Override
+    public Ytelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
+        this.dataBruktTilUtledning = dataBruktTilUtledning;
+        return this;
     }
 
     public OmsorgspengerUtbetaling medFosterbarn(List<Barn> barn) {

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/pls/v1/PleipengerLivetsSluttfase.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/pls/v1/PleipengerLivetsSluttfase.java
@@ -23,6 +23,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Utenlandsopphold;
 import no.nav.k9.søknad.felles.type.Periode;
 import no.nav.k9.søknad.felles.type.Person;
 import no.nav.k9.søknad.felles.validering.periode.LukketPeriode;
+import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 import no.nav.k9.søknad.ytelse.Ytelse;
 import no.nav.k9.søknad.ytelse.YtelseValidator;
 import no.nav.k9.søknad.ytelse.psb.v1.LovbestemtFerie;
@@ -75,6 +76,10 @@ public class PleipengerLivetsSluttfase implements Ytelse {
     @JsonProperty(value = "lovbestemtFerie")
     private LovbestemtFerie lovbestemtFerie = new LovbestemtFerie();
 
+    @JsonProperty(value = "dataBruktTilUtledning")
+    @Valid
+    private DataBruktTilUtledning dataBruktTilUtledning;
+
     @Override
     public Type getType() {
         return Type.PLEIEPENGER_LIVETS_SLUTTFASE;
@@ -83,6 +88,17 @@ public class PleipengerLivetsSluttfase implements Ytelse {
     @Override
     public YtelseValidator getValidator(Versjon versjon) {
         return new PleiepengerLivetsSluttfaseYtelseValidator();
+    }
+
+    @Override
+    public DataBruktTilUtledning getDataBruktTilUtledning() {
+        return this.dataBruktTilUtledning;
+    }
+
+    @Override
+    public Ytelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
+        this.dataBruktTilUtledning = dataBruktTilUtledning;
+        return this;
     }
 
     @Override

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/psb/v1/DataBruktTilUtledning.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/psb/v1/DataBruktTilUtledning.java
@@ -12,10 +12,18 @@ import java.util.List;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
 public class DataBruktTilUtledning {
 
+    /**
+     * @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning}
+     */
+    @Deprecated(forRemoval = true, since = "8.2.1")
     @JsonProperty(value = "harForståttRettigheterOgPlikter")
     @Valid
     private Boolean harForståttRettigheterOgPlikter;
 
+    /**
+     * @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning}
+     */
+    @Deprecated(forRemoval = true, since = "8.2.1")
     @JsonProperty(value = "harBekreftetOpplysninger")
     @Valid
     private Boolean harBekreftetOpplysninger;
@@ -28,6 +36,10 @@ public class DataBruktTilUtledning {
     @Valid
     private Boolean harMedsøker;
 
+    /**
+     * @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning}
+     */
+    @Deprecated(forRemoval = true, since = "8.2.1")
     @JsonProperty(value = "soknadDialogCommitSha")
     @Valid
     private String soknadDialogCommitSha;
@@ -42,14 +54,26 @@ public class DataBruktTilUtledning {
     private List<UkjentArbeidsforhold> ukjenteArbeidsforhold;
 
     @JsonCreator
-    public DataBruktTilUtledning(@JsonProperty(value = "harForståttRettigheterOgPlikter") @Valid Boolean harForståttRettigheterOgPlikter,
-                                 @JsonProperty(value = "harBekreftetOpplysninger") @Valid Boolean harBekreftetOpplysninger,
-                                 @JsonProperty(value = "samtidigHjemme") @Valid Boolean samtidigHjemme,
-                                 @JsonProperty(value = "harMedsøker") @Valid Boolean harMedsøker,
-                                 @JsonProperty(value = "soknadDialogCommitSha") @Valid String soknadDialogCommitSha,
-                                 @JsonProperty(value = "bekrefterPeriodeOver8Uker") @Valid Boolean bekrefterPeriodeOver8Uker,
-                                 @JsonProperty(value = "ukjenteArbeidsforhold") @Valid List<UkjentArbeidsforhold> ukjenteArbeidsforhold
-                                 ) {
+    public DataBruktTilUtledning(
+            /** @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning} */
+            @Deprecated(forRemoval = true, since = "8.2.1")
+            @JsonProperty(value = "harForståttRettigheterOgPlikter") @Valid Boolean harForståttRettigheterOgPlikter,
+
+            /** @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning} */
+            @Deprecated(forRemoval = true, since = "8.2.1")
+            @JsonProperty(value = "harBekreftetOpplysninger") @Valid Boolean harBekreftetOpplysninger,
+
+            @JsonProperty(value = "samtidigHjemme") @Valid Boolean samtidigHjemme,
+            @JsonProperty(value = "harMedsøker") @Valid Boolean harMedsøker,
+
+            /** @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning} */
+            @Deprecated(forRemoval = true, since = "8.2.1")
+            @JsonProperty(value = "soknadDialogCommitSha") @Valid String soknadDialogCommitSha,
+
+            @JsonProperty(value = "bekrefterPeriodeOver8Uker") @Valid Boolean bekrefterPeriodeOver8Uker,
+
+            @JsonProperty(value = "ukjenteArbeidsforhold") @Valid List<UkjentArbeidsforhold> ukjenteArbeidsforhold
+    ) {
 
         this.harForståttRettigheterOgPlikter = harForståttRettigheterOgPlikter;
         this.harBekreftetOpplysninger = harBekreftetOpplysninger;
@@ -63,19 +87,35 @@ public class DataBruktTilUtledning {
     public DataBruktTilUtledning() {
     }
 
+    /**
+     * @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning}
+     */
+    @Deprecated(forRemoval = true, since = "8.2.1")
     public Boolean getHarForståttRettigheterOgPlikter() {
         return harForståttRettigheterOgPlikter;
     }
 
+    /**
+     * @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning}
+     */
+    @Deprecated(forRemoval = true, since = "8.2.1")
     public DataBruktTilUtledning medHarForståttRettigheterOgPlikter(Boolean harForståttRettigheterOgPlikter) {
         this.harForståttRettigheterOgPlikter = harForståttRettigheterOgPlikter;
         return this;
     }
 
+    /**
+     * @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning}
+     */
+    @Deprecated(forRemoval = true, since = "8.2.1")
     public Boolean getHarBekreftetOpplysninger() {
         return harBekreftetOpplysninger;
     }
 
+    /**
+     * @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning}
+     */
+    @Deprecated(forRemoval = true, since = "8.2.1")
     public DataBruktTilUtledning medHarBekreftetOpplysninger(Boolean harBekreftetOpplysninger) {
         this.harBekreftetOpplysninger = harBekreftetOpplysninger;
         return this;
@@ -99,10 +139,18 @@ public class DataBruktTilUtledning {
         return this;
     }
 
+    /**
+     * @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning}
+     */
+    @Deprecated(forRemoval = true, since = "8.2.1")
     public String getSoknadDialogCommitSha() {
         return this.soknadDialogCommitSha;
     }
 
+    /**
+     * @deprecated flyttes til  {@link no.nav.k9.søknad.ytelse.DataBruktTilUtledning}
+     */
+    @Deprecated(forRemoval = true, since = "8.2.1")
     public DataBruktTilUtledning medSoknadDialogCommitSha(String soknadDialogCommitSha) {
         this.soknadDialogCommitSha = soknadDialogCommitSha;
         return this;

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/psb/v1/PleiepengerSyktBarn.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/psb/v1/PleiepengerSyktBarn.java
@@ -65,6 +65,10 @@ public class PleiepengerSyktBarn implements Ytelse {
     @JsonProperty(value = "dataBruktTilUtledning")
     private DataBruktTilUtledning dataBruktTilUtledning;
 
+    @JsonProperty(value = "annetDataBruktTilUtledning")
+    @Valid
+    private no.nav.k9.søknad.ytelse.DataBruktTilUtledning annetDataBruktTilUtledning;
+
     @Deprecated
     @Valid
     @JsonProperty(value = "infoFraPunsj")
@@ -325,6 +329,17 @@ public class PleiepengerSyktBarn implements Ytelse {
     @Override
     public YtelseValidator getValidator(Versjon versjon) {
         return new PleiepengerSyktBarnYtelseValidator();
+    }
+
+    @Override
+    public no.nav.k9.søknad.ytelse.DataBruktTilUtledning getDataBruktTilUtledning() {
+        return this.annetDataBruktTilUtledning;
+    }
+
+    @Override
+    public Ytelse medDataBruktTilUtledning(no.nav.k9.søknad.ytelse.DataBruktTilUtledning dataBruktTilUtledning) {
+        this.annetDataBruktTilUtledning = dataBruktTilUtledning;
+        return this;
     }
 
 

--- a/soknad/src/test/java/no/nav/k9/søknad/ytelse/DataBruktTilUtledningTest.java
+++ b/soknad/src/test/java/no/nav/k9/søknad/ytelse/DataBruktTilUtledningTest.java
@@ -1,0 +1,125 @@
+package no.nav.k9.søknad.ytelse;
+
+import no.nav.k9.søknad.JsonUtils;
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class DataBruktTilUtledningTest {
+
+    private DataBruktTilUtledning dataBruktTilUtledning;
+
+    @BeforeEach
+    void setUp() {
+        this.dataBruktTilUtledning = new DataBruktTilUtledning();
+    }
+
+    @Test
+    public void testSerialiseringMedSetter() throws JSONException {
+        Map<String, Object> data = new HashMap<>();
+        data.put("string", "tekst");
+        data.put("tall", 1000);
+        data.put("boolean", true);
+        data.put("objekt", Map.of("string", "tekst"));
+        data.put("liste", List.of(Map.of("string", "tekst")));
+        dataBruktTilUtledning
+                .medHarBekreftetOpplysninger(true)
+                .medHarForståttRettigheterOgPlikter(true)
+                .medSoknadDialogCommitSha("1234567890")
+                .setAnnetData(data);
+
+        String serialisertData = JsonUtils.toString(dataBruktTilUtledning);
+        JSONAssert.assertEquals("""
+                {
+                  "harBekreftetOpplysninger": true,
+                  "harForståttRettigheterOgPlikter": true,
+                  "soknadDialogCommitSha": "1234567890",
+                  "annetData" : {
+                    "string" : "tekst",
+                    "tall" : 1000,
+                    "boolean" : true,
+                    "objekt" : {
+                      "string" : "tekst"
+                    },
+                    "liste" : [ {
+                      "string" : "tekst"
+                    } ]
+                  }
+                }
+                """, serialisertData, true);
+    }
+
+    @Test
+    public void testSerialiseringMedData() throws JSONException {
+        dataBruktTilUtledning
+                .medHarBekreftetOpplysninger(true)
+                .medHarForståttRettigheterOgPlikter(true)
+                .medSoknadDialogCommitSha("1234567890")
+                .medData("string", "tekst")
+                .medData("tall", 1000)
+                .medData("boolean", true)
+                .medData("objekt", Map.of("string", "tekst"))
+                .medData("liste", List.of(Map.of("string", "tekst")));
+
+        String serialisertData = JsonUtils.toString(dataBruktTilUtledning);
+        JSONAssert.assertEquals("""
+                {
+                  "harBekreftetOpplysninger": true,
+                  "harForståttRettigheterOgPlikter": true,
+                  "soknadDialogCommitSha": "1234567890",
+                  "annetData" : {
+                    "string" : "tekst",
+                    "tall" : 1000,
+                    "boolean" : true,
+                    "objekt" : {
+                      "string" : "tekst"
+                    },
+                    "liste" : [ {
+                      "string" : "tekst"
+                    } ]
+                  }
+                }
+                """, serialisertData, true);
+    }
+
+    @Test
+    public void testDeserialisering() throws JSONException {
+        String jsonString = """
+                {
+                  "harBekreftetOpplysninger": true,
+                  "harForståttRettigheterOgPlikter": true,
+                  "soknadDialogCommitSha": "1234567890",
+                  "annetData" : {
+                    "string" : "tekst",
+                    "tall" : 1000,
+                    "boolean" : true,
+                    "objekt" : {
+                      "string" : "tekst"
+                    },
+                    "liste" : [ {
+                      "string" : "tekst"
+                    } ]
+                  }
+                }
+                """;
+
+        DataBruktTilUtledning deserialisertData = JsonUtils.fromString(jsonString, DataBruktTilUtledning.class);
+        DataBruktTilUtledning forventetDataBruktTilUtledning = new DataBruktTilUtledning()
+                .medHarBekreftetOpplysninger(true)
+                .medHarForståttRettigheterOgPlikter(true)
+                .medSoknadDialogCommitSha("1234567890")
+                .setAnnetData(Map.of(
+                "string", "tekst",
+                "tall", 1000,
+                "boolean", true,
+                "objekt", Map.of("string", "tekst"),
+                "liste", List.of(Map.of("string", "tekst"))
+        ));
+        JSONAssert.assertEquals(forventetDataBruktTilUtledning.toString(), deserialisertData.toString(), true);
+    }
+}


### PR DESCRIPTION
Markerer felles felter for flytting til nytt struktur som `@Deprecated` i gammel struktur, felles for PSB og OLP.