### PR TITLE
endrer til å bruke journalpostid istedenfor søknadid da det er enkler…

### DIFF
--- a/innsyn/src/main/java/no/nav/k9/innsyn/sak/SøknadInfo.java
+++ b/innsyn/src/main/java/no/nav/k9/innsyn/sak/SøknadInfo.java
@@ -1,11 +1,15 @@
 package no.nav.k9.innsyn.sak;
 
+import java.time.ZonedDateTime;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-
-import java.time.ZonedDateTime;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import no.nav.k9.søknad.felles.Kildesystem;
 
 public record SøknadInfo(
 
@@ -14,15 +18,22 @@ public record SøknadInfo(
         @NotNull
         SøknadStatus status,
 
-        @JsonProperty(value = "søknadId", required = true)
+        @JsonProperty(value = "journalpostId", required = true)
         @Valid
         @NotNull
-        String søknadId,
+        @Size(max = 50, min = 3)
+        @Pattern(regexp = "^[\\\\p{Alnum}]+$", message = "journalpostId [${validatedValue}] matcher ikke tillatt pattern [{regexp}]")
+        String journalpostId,
 
         @JsonProperty(value = "mottattTidspunkt", required = true)
         @Valid
         @NotNull
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
-        ZonedDateTime mottattTidspunkt
+        ZonedDateTime mottattTidspunkt,
+
+        @Valid
+        @JsonProperty(value = "kildesystem")
+        Kildesystem kildesystem
+
 ) {
 }

--- a/innsyn/src/test/java/no/nav/k9/innsyn/sak/BehandlingTest.java
+++ b/innsyn/src/test/java/no/nav/k9/innsyn/sak/BehandlingTest.java
@@ -1,11 +1,6 @@
 package no.nav.k9.innsyn.sak;
 
-import no.nav.k9.innsyn.InnsynHendelse;
-import no.nav.k9.kodeverk.behandling.FagsakYtelseType;
-import no.nav.k9.sak.typer.AktørId;
-import no.nav.k9.sak.typer.Saksnummer;
-import no.nav.k9.søknad.JsonUtils;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -16,7 +11,14 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import no.nav.k9.innsyn.InnsynHendelse;
+import no.nav.k9.kodeverk.behandling.FagsakYtelseType;
+import no.nav.k9.sak.typer.AktørId;
+import no.nav.k9.sak.typer.Saksnummer;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.felles.Kildesystem;
 
 class BehandlingTest {
 
@@ -52,8 +54,9 @@ class BehandlingTest {
                     "søknader": [
                       {
                         "status": "MOTTATT",
-                        "søknadId": "f1b3f3c3-0b1a-4e4a-9b1a-3c3f3b1a4e4a",
-                        "mottattTidspunkt": "2021-06-01T12:00:00.000Z"
+                        "journalpostId": "f1b3f3c3-0b1a-4e4a-9b1a-3c3f3b1a4e4a",
+                        "mottattTidspunkt": "2021-06-01T12:00:00.000Z",
+                        "kildesystem": "søknadsdialog"
                       }
                     ],
                     "aksjonspunkter": [
@@ -83,8 +86,9 @@ class BehandlingTest {
         assertThat(søknader).hasSize(1);
         SøknadInfo søknadInfo = søknader.stream().findFirst().get();
         assertThat(søknadInfo.status()).isEqualTo(SøknadStatus.MOTTATT);
+        assertThat(søknadInfo.kildesystem()).isEqualTo(Kildesystem.SØKNADSDIALOG);
 
-        assertThat(søknadInfo.søknadId()).isEqualTo("f1b3f3c3-0b1a-4e4a-9b1a-3c3f3b1a4e4a");
+        assertThat(søknadInfo.journalpostId()).isEqualTo("f1b3f3c3-0b1a-4e4a-9b1a-3c3f3b1a4e4a");
         assertThat(søknadInfo.mottattTidspunkt()).isEqualTo(ZonedDateTime.parse("2021-06-01T12:00:00.000Z"));
 
         // Aksjonspunkter
@@ -124,7 +128,7 @@ class BehandlingTest {
 
     private static Behandling lagBehandling(boolean erUtenlands, ZonedDateTime... søknadtidspunkter) {
 
-        Set<SøknadInfo> søknader = Arrays.stream(søknadtidspunkter).map(it -> new SøknadInfo(SøknadStatus.MOTTATT, UUID.randomUUID().toString(), it)).collect(Collectors.toSet());
+        Set<SøknadInfo> søknader = Arrays.stream(søknadtidspunkter).map(it -> new SøknadInfo(SøknadStatus.MOTTATT, UUID.randomUUID().toString(), it, Kildesystem.SØKNADSDIALOG)).collect(Collectors.toSet());
 
         Set<Aksjonspunkt> aksjonspunkter = Set.of(
                 new Aksjonspunkt(Aksjonspunkt.Venteårsak.MEDISINSK_DOKUMENTASJON)


### PR DESCRIPTION
…e å sende dette fra k9-sak og innsyn kan gjøre oppslag i sin database for å finne Søknad. Utvider med kildesystem for å skille mellom søknader som kommer fra endringsdialog og søknadsdialog