### PR TITLE
Legger på nye felter  i Behandling.

### DIFF
--- a/innsyn/src/main/java/no/nav/k9/innsyn/TempObjectMapperKodeverdi.java
+++ b/innsyn/src/main/java/no/nav/k9/innsyn/TempObjectMapperKodeverdi.java
@@ -1,0 +1,41 @@
+package no.nav.k9.innsyn;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import no.nav.k9.kodeverk.api.Kodeverdi;
+import no.nav.k9.søknad.JsonUtils;
+
+/**
+ * nødvendig for å kunne serializere k9-sak kodeverdi objekter til string
+ * kan fjernes når k9-sak har tatt i bruk @JsonValue på sine kodeobjekter
+ */
+public class TempObjectMapperKodeverdi {
+
+    public static ObjectMapper getObjectMapper() {
+        var om = JsonUtils.getObjectMapper().copy();
+        var m = new SimpleModule();
+        m.addSerializer(Kodeverdi.class, new TempKodeverdiSerializer());
+        om.registerModule(m);
+        return om;
+    }
+
+    private static class TempKodeverdiSerializer extends StdSerializer<Kodeverdi> {
+
+        public TempKodeverdiSerializer(){
+            super(Kodeverdi.class);
+        }
+
+        @Override
+        public void serialize(Kodeverdi value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeString(value.getKode());
+        }
+    }
+
+}
+

--- a/innsyn/src/main/java/no/nav/k9/innsyn/sak/Aksjonspunkt.java
+++ b/innsyn/src/main/java/no/nav/k9/innsyn/sak/Aksjonspunkt.java
@@ -1,11 +1,15 @@
 package no.nav.k9.innsyn.sak;
 
+import java.time.ZonedDateTime;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 public record Aksjonspunkt(
-        @JsonProperty("venteårsak") @Valid @NotNull Venteårsak venteårsak
+        @JsonProperty("venteårsak") @Valid @NotNull Venteårsak venteårsak,
+        @JsonProperty("tidsfrist") ZonedDateTime tidsfrist
 ) {
 
     public enum Venteårsak {

--- a/innsyn/src/main/java/no/nav/k9/innsyn/sak/Aksjonspunkt.java
+++ b/innsyn/src/main/java/no/nav/k9/innsyn/sak/Aksjonspunkt.java
@@ -13,6 +13,6 @@ public record Aksjonspunkt(
 ) {
 
     public enum Venteårsak {
-        INNTEKTSMELDING, MEDISINSK_DOKUMENTASJON
+        INNTEKTSMELDING, MEDISINSK_DOKUMENTASJON, FOR_TIDLIG_SOKNAD, MELDEKORT
     }
 }

--- a/innsyn/src/main/java/no/nav/k9/innsyn/sak/Behandling.java
+++ b/innsyn/src/main/java/no/nav/k9/innsyn/sak/Behandling.java
@@ -1,18 +1,22 @@
 package no.nav.k9.innsyn.sak;
 
-import com.fasterxml.jackson.annotation.*;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import no.nav.k9.innsyn.InnsynHendelseData;
-import no.nav.k9.konstant.Konstant;
-
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import no.nav.k9.innsyn.InnsynHendelseData;
+import no.nav.k9.konstant.Konstant;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
@@ -23,13 +27,17 @@ public record Behandling(
         @NotNull
         UUID behandlingsId,
 
-        @JsonProperty(value = "opprettetDato", required = true)
+        @JsonProperty(value = "opprettetTidspunkt", required = true)
         @NotNull
-        LocalDate opprettetDato,
+        ZonedDateTime opprettetTidspunkt,
 
         @JsonInclude(value = JsonInclude.Include.NON_NULL)
-        @JsonProperty(value = "avsluttetDato")
-        LocalDate avsluttetDato,
+        @JsonProperty(value = "avsluttetTidspunkt")
+        ZonedDateTime avsluttetTidspunkt,
+
+        @JsonInclude(value = JsonInclude.Include.NON_NULL)
+        @JsonProperty(value = "resultat")
+        BehandlingResultat resultat,
 
         @JsonProperty(value = "status", required = true)
         @Valid

--- a/innsyn/src/main/java/no/nav/k9/innsyn/sak/Behandling.java
+++ b/innsyn/src/main/java/no/nav/k9/innsyn/sak/Behandling.java
@@ -1,6 +1,6 @@
 package no.nav.k9.innsyn.sak;
 
-import java.time.Duration;
+import java.time.Period;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.Optional;
@@ -61,8 +61,8 @@ public record Behandling(
         Fagsak fagsak
 
 ) implements InnsynHendelseData  {
-    public Optional<ZonedDateTime> utledSaksbehandlingsfrist(Duration overstyrSaksbehandlingstid) {
-        if (erUtenlands) {
+    public Optional<ZonedDateTime> utledSaksbehandlingsfrist(Period overstyrSaksbehandlingstid) {
+        if (avsluttetTidspunkt != null) {
             return Optional.empty();
         }
 
@@ -71,7 +71,11 @@ public record Behandling(
                 .map(SøknadInfo::mottattTidspunkt);
 
         return tidligsteMottattDato.map(it -> {
-            Duration saksbehandlingstid = overstyrSaksbehandlingstid != null ? overstyrSaksbehandlingstid : Konstant.FORVENTET_SAKSBEHANDLINGSTID;
+            if (overstyrSaksbehandlingstid != null) {
+                return it.plus(overstyrSaksbehandlingstid);
+            }
+
+            Period saksbehandlingstid = erUtenlands ? Konstant.UTLAND_FORVENTET_SAKSBEHANDLINGSTID : Konstant.FORVENTET_SAKSBEHANDLINGSTID;
             return it.plus(saksbehandlingstid);
         });
     }

--- a/innsyn/src/main/java/no/nav/k9/innsyn/sak/Behandling.java
+++ b/innsyn/src/main/java/no/nav/k9/innsyn/sak/Behandling.java
@@ -1,15 +1,13 @@
 package no.nav.k9.innsyn.sak;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.*;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import no.nav.k9.innsyn.InnsynHendelseData;
 import no.nav.k9.konstant.Konstant;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.Optional;
@@ -24,6 +22,14 @@ public record Behandling(
         @Valid
         @NotNull
         UUID behandlingsId,
+
+        @JsonProperty(value = "opprettetDato", required = true)
+        @NotNull
+        LocalDate opprettetDato,
+
+        @JsonInclude(value = JsonInclude.Include.NON_NULL)
+        @JsonProperty(value = "avsluttetDato")
+        LocalDate avsluttetDato,
 
         @JsonProperty(value = "status", required = true)
         @Valid

--- a/innsyn/src/main/java/no/nav/k9/innsyn/sak/BehandlingResultat.java
+++ b/innsyn/src/main/java/no/nav/k9/innsyn/sak/BehandlingResultat.java
@@ -1,0 +1,5 @@
+package no.nav.k9.innsyn.sak;
+
+public enum BehandlingResultat {
+    INNVILGET, DELVIS_INNVILGET, AVSLÅTT, HENLAGT, OPPHØRT
+}

--- a/innsyn/src/main/java/no/nav/k9/innsyn/sak/BehandlingResultat.java
+++ b/innsyn/src/main/java/no/nav/k9/innsyn/sak/BehandlingResultat.java
@@ -1,5 +1,5 @@
 package no.nav.k9.innsyn.sak;
 
 public enum BehandlingResultat {
-    INNVILGET, DELVIS_INNVILGET, AVSLÅTT, HENLAGT, OPPHØRT
+    INNVILGET, DELVIS_INNVILGET, AVSLÅTT, HENLAGT
 }

--- a/innsyn/src/main/java/no/nav/k9/innsyn/sak/BehandlingStatus.java
+++ b/innsyn/src/main/java/no/nav/k9/innsyn/sak/BehandlingStatus.java
@@ -4,5 +4,5 @@ package no.nav.k9.innsyn.sak;
  * @see <a href="https://github.com/navikt/k9-sak/blob/fcaffc46d11cb5cc10738ad5cc34d981b0fbcff1/kodeverk/src/main/java/no/nav/k9/kodeverk/behandling/BehandlingStatus.java">BehandlingStatus i k9-sak</a>
  */
 public enum BehandlingStatus {
-    OPPRETTET, UNDER_BEHANDLING, PAA_VENT, AVSLUTTET
+    OPPRETTET, UNDER_BEHANDLING, PÅ_VENT, AVSLUTTET
 }

--- a/innsyn/src/test/java/no/nav/k9/innsyn/sak/BehandlingTest.java
+++ b/innsyn/src/test/java/no/nav/k9/innsyn/sak/BehandlingTest.java
@@ -2,7 +2,10 @@ package no.nav.k9.innsyn.sak;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.*;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.UUID;
@@ -40,7 +43,7 @@ class BehandlingTest {
                   "data": {
                     "type": "BEHANDLING_INNHOLD",
                     "behandlingsId": "f1b3f3c3-0b1a-4e4a-9b1a-3c3f3b1a4e4a",
-                    "opprettetDato": "2024-02-13",
+                    "opprettetTidspunkt": "2024-02-13T12:00:00.000Z",
                     "fagsak": {
                       "saksnummer": "ABC123",
                       "søkerAktørId": "11111111111",
@@ -49,6 +52,8 @@ class BehandlingTest {
                     },
                     "status": "OPPRETTET",
                     "erUtenlands": "false",
+                    "avsluttetTidspunkt": "2024-02-14T12:00:00.000Z",
+                    "behandlingResultat": "INNVILGET",
                     "søknader": [
                       {
                         "status": "MOTTATT",
@@ -59,7 +64,8 @@ class BehandlingTest {
                     ],
                     "aksjonspunkter": [
                       {
-                        "venteårsak": "INNTEKTSMELDING"
+                        "venteårsak": "INNTEKTSMELDING",
+                        "tidsfrist": "2024-02-15T12:00:00.000Z"
                       }
                     ]
                   }
@@ -77,7 +83,11 @@ class BehandlingTest {
         // behandlinger
         assertThat(behandling.status()).isEqualTo(BehandlingStatus.OPPRETTET);
         assertThat(behandling.erUtenlands()).isFalse();
+        assertThat(behandling.opprettetTidspunkt()).isEqualTo(ZonedDateTime.parse("2024-02-13T12:00:00.000Z"));
+        assertThat(behandling.avsluttetTidspunkt()).isEqualTo(ZonedDateTime.parse("2024-02-14T12:00:00.000Z"));
+        assertThat(behandling.erUtenlands()).isFalse();
         assertThat(behandling.behandlingsId()).isEqualTo(UUID.fromString("f1b3f3c3-0b1a-4e4a-9b1a-3c3f3b1a4e4a"));
+
 
         // Søknader
         Set<SøknadInfo> søknader = behandling.søknader();
@@ -94,6 +104,7 @@ class BehandlingTest {
         assertThat(aksjonspunkter).hasSize(1);
         Aksjonspunkt aksjonspunkt = aksjonspunkter.stream().findFirst().get();
         assertThat(aksjonspunkt.venteårsak()).isEqualTo(Aksjonspunkt.Venteårsak.INNTEKTSMELDING);
+        assertThat(aksjonspunkt.tidsfrist()).isEqualTo(ZonedDateTime.parse("2024-02-15T12:00:00.000Z"));
     }
 
     @Test
@@ -129,7 +140,7 @@ class BehandlingTest {
         Set<SøknadInfo> søknader = Arrays.stream(søknadtidspunkter).map(it -> new SøknadInfo(SøknadStatus.MOTTATT, UUID.randomUUID().toString(), it, Kildesystem.SØKNADSDIALOG)).collect(Collectors.toSet());
 
         Set<Aksjonspunkt> aksjonspunkter = Set.of(
-                new Aksjonspunkt(Aksjonspunkt.Venteårsak.MEDISINSK_DOKUMENTASJON)
+                new Aksjonspunkt(Aksjonspunkt.Venteårsak.MEDISINSK_DOKUMENTASJON, ZonedDateTime.now())
         );
 
         String saksnummer = "ABC123";
@@ -145,8 +156,9 @@ class BehandlingTest {
 
         Behandling behandling = new Behandling(
                 UUID.randomUUID(),
-                LocalDate.now(),
-                null,
+                ZonedDateTime.now(),
+                ZonedDateTime.now(),
+                BehandlingResultat.INNVILGET,
                 BehandlingStatus.OPPRETTET,
                 søknader,
                 aksjonspunkter,

--- a/innsyn/src/test/java/no/nav/k9/innsyn/sak/BehandlingTest.java
+++ b/innsyn/src/test/java/no/nav/k9/innsyn/sak/BehandlingTest.java
@@ -2,8 +2,8 @@ package no.nav.k9.innsyn.sak;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.time.LocalDate;
+import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -115,20 +115,22 @@ class BehandlingTest {
         assertThat(saksbehandlingsfrist).isEqualTo(tidligsteMottattTidspunkt.plusWeeks(6));
     }
 
+
+
     @Test
     void skalOverstureOgRegneUtSaksbehandlingsfrist() {
         ZonedDateTime tidligsteMottattTidspunkt = LocalDate.of(2024, 1, 5).atStartOfDay(ZoneId.systemDefault());
         var behandling = lagBehandling(false, tidligsteMottattTidspunkt.plusDays(10), tidligsteMottattTidspunkt, tidligsteMottattTidspunkt.plusMonths(20));
-        ZonedDateTime saksbehandlingsfrist = behandling.utledSaksbehandlingsfrist(Duration.ofDays(5)).get();
+        ZonedDateTime saksbehandlingsfrist = behandling.utledSaksbehandlingsfrist(Period.ofDays(5)).get();
         assertThat(saksbehandlingsfrist).isEqualTo(tidligsteMottattTidspunkt.plusDays(5));
     }
 
     @Test
-    void skalIkkeRegneUtSaksbehandlingsfristForUtenlandsbehandling() {
-        ZonedDateTime mottattidspunkt = LocalDate.of(2024, 1, 5).atStartOfDay(ZoneId.systemDefault());
-        var behandling = lagBehandling(true, mottattidspunkt);
-        var saksbehandlingsfrist = behandling.utledSaksbehandlingsfrist(null);
-        assertThat(saksbehandlingsfrist).isEmpty();
+    void skalRegneUtSaksbehandlingsfristUtland() {
+        ZonedDateTime tidligsteMottattTidspunkt = LocalDate.of(2024, 1, 5).atStartOfDay(ZoneId.systemDefault());
+        var behandling = lagBehandling(true, tidligsteMottattTidspunkt.plusDays(10), tidligsteMottattTidspunkt, tidligsteMottattTidspunkt.plusMonths(20));
+        ZonedDateTime saksbehandlingsfrist = behandling.utledSaksbehandlingsfrist(null).get();
+        assertThat(saksbehandlingsfrist).isEqualTo(tidligsteMottattTidspunkt.plusMonths(6));
     }
 
     private static Behandling lagBehandling() {
@@ -157,7 +159,7 @@ class BehandlingTest {
         Behandling behandling = new Behandling(
                 UUID.randomUUID(),
                 ZonedDateTime.now(),
-                ZonedDateTime.now(),
+                null,
                 BehandlingResultat.INNVILGET,
                 BehandlingStatus.OPPRETTET,
                 søknader,

--- a/innsyn/src/test/java/no/nav/k9/innsyn/sak/BehandlingTest.java
+++ b/innsyn/src/test/java/no/nav/k9/innsyn/sak/BehandlingTest.java
@@ -2,10 +2,7 @@ package no.nav.k9.innsyn.sak;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.UUID;
@@ -43,6 +40,7 @@ class BehandlingTest {
                   "data": {
                     "type": "BEHANDLING_INNHOLD",
                     "behandlingsId": "f1b3f3c3-0b1a-4e4a-9b1a-3c3f3b1a4e4a",
+                    "opprettetDato": "2024-02-13",
                     "fagsak": {
                       "saksnummer": "ABC123",
                       "søkerAktørId": "11111111111",
@@ -147,6 +145,8 @@ class BehandlingTest {
 
         Behandling behandling = new Behandling(
                 UUID.randomUUID(),
+                LocalDate.now(),
+                null,
                 BehandlingStatus.OPPRETTET,
                 søknader,
                 aksjonspunkter,

--- a/innsyn/src/test/java/no/nav/k9/innsyn/sak/BehandlingTest.java
+++ b/innsyn/src/test/java/no/nav/k9/innsyn/sak/BehandlingTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import no.nav.k9.innsyn.InnsynHendelse;
+import no.nav.k9.innsyn.TempObjectMapperKodeverdi;
 import no.nav.k9.kodeverk.behandling.FagsakYtelseType;
 import no.nav.k9.sak.typer.AktørId;
 import no.nav.k9.sak.typer.Saksnummer;
@@ -105,6 +106,9 @@ class BehandlingTest {
         Aksjonspunkt aksjonspunkt = aksjonspunkter.stream().findFirst().get();
         assertThat(aksjonspunkt.venteårsak()).isEqualTo(Aksjonspunkt.Venteårsak.INNTEKTSMELDING);
         assertThat(aksjonspunkt.tidsfrist()).isEqualTo(ZonedDateTime.parse("2024-02-15T12:00:00.000Z"));
+
+        String json = JsonUtils.toString(hendelse, TempObjectMapperKodeverdi.getObjectMapper());
+        assertThat(json).doesNotContain("kodeverk");
     }
 
     @Test

--- a/konstant/src/main/java/no/nav/k9/konstant/Konstant.java
+++ b/konstant/src/main/java/no/nav/k9/konstant/Konstant.java
@@ -1,14 +1,11 @@
 package no.nav.k9.konstant;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
+import java.time.Period;
 
 public class Konstant {
-    private static final Long SAKSBEHANDLINGSTID_UKER = 6L;
-    private static final Long ANTALL_UKEDAGER = 7L;
-    /*
-     * ChronoUnit.WEEKS har ikke en fast varighet fordi lengden av en uke kan variere for eksempel, pga.sommertid).
-     * Bruker derfor ChronoUnit.DAYS for å være sikker på at vi får riktig varighet.
-     */
-    public static final Duration FORVENTET_SAKSBEHANDLINGSTID = Duration.of(SAKSBEHANDLINGSTID_UKER * ANTALL_UKEDAGER, ChronoUnit.DAYS);
+    private static final String SAKSBEHANDLINGSTID = "P6W";
+    private static final String UTLAND_SAKSBEHANDLINGSTID = "P6M";
+
+    public static final Period FORVENTET_SAKSBEHANDLINGSTID = Period.parse(SAKSBEHANDLINGSTID);
+    public static final Period UTLAND_FORVENTET_SAKSBEHANDLINGSTID = Period.parse(UTLAND_SAKSBEHANDLINGSTID);
 }

--- a/soknad/src/main/java/no/nav/k9/søknad/JsonUtils.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/JsonUtils.java
@@ -27,6 +27,14 @@ public final class JsonUtils {
     }
 
     public static String toString(Object object) {
+        return toString(object, objectMapper);
+    }
+
+    /**
+     * Tillater å override objectmapper. Nødvendig i en overgangsfase mens Kodeverdi objekter i k9sak
+     * overføres til @JsonValue
+     */
+    public static String toString(Object object, ObjectMapper objectMapper) {
         try {
             return objectMapper.writer(new PlatformIndependentPrettyPrinter()).writeValueAsString(object);
         } catch (JsonProcessingException e) {


### PR DESCRIPTION
Disse endringene vil medføre til deserialiseringsfeil for allerede persistere behandlinger uten disse feltene. 
Det kan løses enten via republisering av de dataene, eller ved å gjøre dem nullable.

- aksjonspunkt.tidsfrist: når behandlingen går av vent
- behandling.opprettetTidspunkt og avsluttetTidspunkt
- behandling.behandlingResultat: resultat på behandling hvis avsluttet. Bruker eget enum fordi ønsker ikke å eksponere alle resultattypene
- bruker æøå i enum slik som i k9-sak