### PR TITLE
Legger til CustomZonedDateTimeDeSerializer for håndtering av ZDT.

### DIFF
--- a/ettersendelse/src/main/java/no/nav/k9/ettersendelse/Ettersendelse.java
+++ b/ettersendelse/src/main/java/no/nav/k9/ettersendelse/Ettersendelse.java
@@ -1,23 +1,18 @@
 package no.nav.k9.ettersendelse;
 
-import java.io.IOException;
-import java.time.ZonedDateTime;
-
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import no.nav.k9.søknad.Innsending;
 import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.felles.DtoKonstanter;
 import no.nav.k9.søknad.felles.Versjon;
 import no.nav.k9.søknad.felles.personopplysninger.Søker;
 import no.nav.k9.søknad.felles.type.SøknadId;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
@@ -34,7 +29,7 @@ public class Ettersendelse implements Innsending {
 
     @JsonProperty(value="mottattDato")
     @Valid
-    @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DtoKonstanter.DATO_TID_FORMAT, timezone = DtoKonstanter.TIDSSONE)
     private final ZonedDateTime mottattDato;
 
     @JsonProperty(value="søker", required = true)

--- a/soknad/src/main/java/no/nav/k9/søknad/CustomZonedDateTimeDeSerializer.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/CustomZonedDateTimeDeSerializer.java
@@ -14,11 +14,20 @@ import java.time.temporal.ChronoField;
 public class CustomZonedDateTimeDeSerializer extends JsonDeserializer<ZonedDateTime> {
 
     static final DateTimeFormatter zonedDateTimeFormatter = new DateTimeFormatterBuilder()
+            // 2024-08-14T10:05:56
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
             .optionalStart()
+            // 2024-08-14T10:05:56.111
             .appendFraction(ChronoField.MILLI_OF_SECOND, 0, 9, true)
             .optionalEnd()
+            // 2024-08-14T10:05:56.111+02:00
             .appendPattern("ZZZZZ")
+            .optionalStart()
+            // 2024-08-14T10:05:56.111+02:00[Europe/Oslo]
+            .appendLiteral('[')
+            .appendZoneRegionId()
+            .appendLiteral(']')
+            .optionalEnd()
             .toFormatter();
 
     @Override

--- a/soknad/src/main/java/no/nav/k9/søknad/CustomZonedDateTimeDeSerializer.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/CustomZonedDateTimeDeSerializer.java
@@ -1,0 +1,29 @@
+package no.nav.k9.søknad;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+public class CustomZonedDateTimeDeSerializer extends JsonDeserializer<ZonedDateTime> {
+
+    static final DateTimeFormatter zonedDateTimeFormatter = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .optionalStart()
+            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
+            .optionalEnd()
+            .appendPattern("XXX")
+            .toFormatter();
+
+    @Override
+    public ZonedDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        String value = p.getValueAsString();
+        return ZonedDateTime.parse(value, zonedDateTimeFormatter);
+    }
+}

--- a/soknad/src/main/java/no/nav/k9/søknad/CustomZonedDateTimeDeSerializer.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/CustomZonedDateTimeDeSerializer.java
@@ -18,7 +18,7 @@ public class CustomZonedDateTimeDeSerializer extends JsonDeserializer<ZonedDateT
             .optionalStart()
             .appendFraction(ChronoField.MILLI_OF_SECOND, 0, 9, true)
             .optionalEnd()
-            .appendPattern("XXX")
+            .appendPattern("ZZZZZ")
             .toFormatter();
 
     @Override

--- a/soknad/src/main/java/no/nav/k9/søknad/CustomZonedDateTimeDeSerializer.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/CustomZonedDateTimeDeSerializer.java
@@ -16,7 +16,7 @@ public class CustomZonedDateTimeDeSerializer extends JsonDeserializer<ZonedDateT
     static final DateTimeFormatter zonedDateTimeFormatter = new DateTimeFormatterBuilder()
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
             .optionalStart()
-            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
+            .appendFraction(ChronoField.MILLI_OF_SECOND, 0, 9, true)
             .optionalEnd()
             .appendPattern("XXX")
             .toFormatter();

--- a/soknad/src/main/java/no/nav/k9/søknad/JsonUtils.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/JsonUtils.java
@@ -1,23 +1,21 @@
 package no.nav.k9.søknad;
 
-import java.io.IOException;
-import java.util.TimeZone;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
+import no.nav.k9.søknad.felles.DtoKonstanter;
 import no.nav.k9.søknad.ytelse.omsorgspenger.v1.OmsorgspengerUtbetaling;
 import no.nav.k9.søknad.ytelse.psb.v1.PleiepengerSyktBarn;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.util.TimeZone;
 
 public final class JsonUtils {
 
@@ -59,9 +57,13 @@ public final class JsonUtils {
     }
 
     private static final ObjectMapper createObjectMapper() {
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        javaTimeModule.addDeserializer(ZonedDateTime.class, new CustomZonedDateTimeDeSerializer());
+
+
         final ObjectMapper objectMapper = new ObjectMapper()
                 .registerModule(new Jdk8Module())
-                .registerModule(new JavaTimeModule())
+                .registerModule(javaTimeModule)
                 .setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE)
                 .setTimeZone(TimeZone.getTimeZone("UTC"))
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
@@ -74,6 +76,7 @@ public final class JsonUtils {
                 .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
 
         objectMapper.registerSubtypes(OmsorgspengerUtbetaling.class, PleiepengerSyktBarn.class);
+        objectMapper.setDateFormat(new SimpleDateFormat(DtoKonstanter.DATO_TID_FORMAT));
 
         return objectMapper;
     }

--- a/soknad/src/main/java/no/nav/k9/søknad/Søknad.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/Søknad.java
@@ -1,21 +1,7 @@
 package no.nav.k9.søknad;
 
-import java.io.IOException;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -23,12 +9,12 @@ import no.nav.k9.søknad.felles.DtoKonstanter;
 import no.nav.k9.søknad.felles.Kildesystem;
 import no.nav.k9.søknad.felles.Versjon;
 import no.nav.k9.søknad.felles.personopplysninger.Søker;
-import no.nav.k9.søknad.felles.type.BegrunnelseForInnsending;
-import no.nav.k9.søknad.felles.type.Journalpost;
-import no.nav.k9.søknad.felles.type.Person;
-import no.nav.k9.søknad.felles.type.Språk;
-import no.nav.k9.søknad.felles.type.SøknadId;
+import no.nav.k9.søknad.felles.type.*;
 import no.nav.k9.søknad.ytelse.Ytelse;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.*;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
@@ -46,7 +32,8 @@ public class Søknad implements Innsending {
 
     @Valid
     @NotNull
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DtoKonstanter.DATO_TID_FORMAT, timezone = DtoKonstanter.TIDSSONE)    @JsonProperty(value = "mottattDato", required = true)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DtoKonstanter.DATO_TID_FORMAT, timezone = DtoKonstanter.TIDSSONE)
+    @JsonProperty(value = "mottattDato", required = true)
     private ZonedDateTime mottattDato;
 
     @Valid
@@ -72,7 +59,7 @@ public class Søknad implements Innsending {
     @NotNull
     @JsonProperty(value = "ytelse", required = true)
     private Ytelse ytelse;
-    
+
     @Valid
     @JsonProperty(value = "kildesystem", required = false)
     private Kildesystem kildesystem;
@@ -144,14 +131,14 @@ public class Søknad implements Innsending {
     public <Y extends Ytelse> Y getYtelse() {
         return (Y) ytelse;
     }
-    
+
     /**
      * Dette feltet kan brukes til å oppgi kildesystem. For historiske data
      * er feltet kun garantert å være satt for alle søknader som kommer fra
      * endringsdialogen. Ved behov for å se på historiske data av andre typer,
      * se på journalpostens kanalfelt og/eller metadatafeltet på journalposten
-     * kalt "k9.kilde". 
-     * 
+     * kalt "k9.kilde".
+     *
      * @return Systemet som søknadsdataene kommer fra.
      */
     public Optional<Kildesystem> getKildesystem() {
@@ -177,7 +164,7 @@ public class Søknad implements Innsending {
     public void setYtelse(Ytelse ytelse) {
         this.ytelse = Objects.requireNonNull(ytelse, "ytelse");
     }
-    
+
     public void setKildesystem(Kildesystem kildesystem) {
         this.kildesystem = kildesystem;
     }
@@ -236,7 +223,7 @@ public class Søknad implements Innsending {
         this.journalposter.addAll(Objects.requireNonNull(journalposter, "journalposter"));
         return this;
     }
-    
+
     /**
      * @see #getKildesystem()
      */

--- a/soknad/src/test/java/no/nav/k9/søknad/JsonUtilsTest.java
+++ b/soknad/src/test/java/no/nav/k9/søknad/JsonUtilsTest.java
@@ -75,7 +75,8 @@ public class JsonUtilsTest {
             "2024-08-14T10:05:56.111Z",
             "2024-08-14T10:05:56.11Z",
             "2024-08-14T10:05:56.1Z",
-            "2024-08-14T10:05:56Z"
+            "2024-08-14T10:05:56Z",
+            "2024-08-14T10:05:56.111+02:00",
     })
     public void deserialisering_av_zdt_skal_ikke_feile(String dato) {
         assertThatNoException().isThrownBy(() -> ZonedDateTime.parse(dato, CustomZonedDateTimeDeSerializer.zonedDateTimeFormatter));

--- a/soknad/src/test/java/no/nav/k9/søknad/JsonUtilsTest.java
+++ b/soknad/src/test/java/no/nav/k9/søknad/JsonUtilsTest.java
@@ -77,6 +77,7 @@ public class JsonUtilsTest {
             "2024-08-14T10:05:56.1Z",
             "2024-08-14T10:05:56Z",
             "2024-08-14T10:05:56.111+02:00",
+            "2024-08-14T10:05:56.111+02:00[Europe/Oslo]",
     })
     public void deserialisering_av_zdt_skal_ikke_feile(String dato) {
         assertThatNoException().isThrownBy(() -> ZonedDateTime.parse(dato, CustomZonedDateTimeDeSerializer.zonedDateTimeFormatter));

--- a/soknad/src/test/java/no/nav/k9/søknad/JsonUtilsTest.java
+++ b/soknad/src/test/java/no/nav/k9/søknad/JsonUtilsTest.java
@@ -11,6 +11,7 @@ import java.time.format.DateTimeParseException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
 
 public class JsonUtilsTest {
 
@@ -74,7 +75,7 @@ public class JsonUtilsTest {
             "2024-08-14T10:05:56Z"
     })
     public void deserialisering_av_zdt_skal_ikke_feile(String dato) {
-        ZonedDateTime.parse(dato, CustomZonedDateTimeDeSerializer.zonedDateTimeFormatter);
+        assertThatNoException().isThrownBy(() -> ZonedDateTime.parse(dato, CustomZonedDateTimeDeSerializer.zonedDateTimeFormatter));
     }
 
     @ParameterizedTest

--- a/soknad/src/test/java/no/nav/k9/søknad/JsonUtilsTest.java
+++ b/soknad/src/test/java/no/nav/k9/søknad/JsonUtilsTest.java
@@ -66,6 +66,9 @@ public class JsonUtilsTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            "2024-08-14T10:05:56.111111111Z",
+            "2024-08-14T10:05:56.11111111Z",
+            "2024-08-14T10:05:56.1111111Z",
             "2024-08-14T10:05:56.111111Z",
             "2024-08-14T10:05:56.11111Z",
             "2024-08-14T10:05:56.1111Z",
@@ -80,7 +83,7 @@ public class JsonUtilsTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-            "2024-08-14T10:05:56.1111111Z",
+            "2024-08-14T10:05:56.1111111111Z",
             "2024-08-14T10:05Z"
     })
     public void deserialisering_av_zdt_skal_feile(String dato) {


### PR DESCRIPTION
CustomZonedDateTimeDeSerializer støtter deserialisering av zdt uten og med ms fra 0-6 siffer. ZDT uten sekund del skal fortsatt feile.

Se tester for ønsket oppførsel.
Ved å legge tilbake pattern i JsonFormat spesifiserer hvordan ZDT skal serialiseres. Altså med 3-sifret ms.
