### PR TITLE
Fikser validering og json-properties i ungdomsytelsekontrakt

### DIFF
--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/ung/v1/Ungdomsytelse.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/ung/v1/Ungdomsytelse.java
@@ -20,16 +20,18 @@ import java.util.Objects;
 
 public class Ungdomsytelse implements Ytelse {
 
+    @Valid
+    @JsonProperty(value = "søknadType", required = true)
     private UngSøknadstype søknadType = UngSøknadstype.DELTAKELSE_SØKNAD;
 
     @Valid
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-    @JsonProperty(value = "søknadsperiode", required = true)
+    @JsonProperty(value = "søktFraDatoer", required = true)
     @NotNull
     private List<@NotNull LocalDate> søktFraDatoer = new ArrayList<>();
 
     @Valid
-    @JsonProperty(value = "inntekter", required = true)
+    @JsonProperty(value = "inntekter", required = false)
     private OppgittInntekt inntekter;
 
     @Override

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/ung/v1/UngdomsytelseSøknadValidator.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/ung/v1/UngdomsytelseSøknadValidator.java
@@ -33,6 +33,10 @@ public class UngdomsytelseSøknadValidator extends SøknadValidator<Søknad> {
             feil.add(new Feil("søktFraDatoer", PÅKREVD, "Deltakelsesøknad må sette minst en startdato"));
         }
 
+        if (ytelse.getSøknadType() == UngSøknadstype.RAPPORTERING_SØKNAD && ytelse.getInntekter() == null) {
+            feil.add(new Feil("inntekter", PÅKREVD, "Rapporteringsinnsending må sette inntekter"));
+        }
+
         return feil;
     }
 


### PR DESCRIPTION
* Fikser json-prop for startdatoer
* Legger til json-property annotasjon for søknadtype
* Flytter notnull validering av inntekter til søknadvalidator