### PR TITLE
Fiks: Endre forventet saksbehandlingstid til fem uker

### DIFF
--- a/konstant/src/main/java/no/nav/k9/konstant/Konstant.java
+++ b/konstant/src/main/java/no/nav/k9/konstant/Konstant.java
@@ -3,7 +3,7 @@ package no.nav.k9.konstant;
 import java.time.Period;
 
 public class Konstant {
-    private static final String SAKSBEHANDLINGSTID = "P4W";
+    private static final String SAKSBEHANDLINGSTID = "P5W";
     private static final String UTLAND_SAKSBEHANDLINGSTID = "P6M";
 
     public static final Period FORVENTET_SAKSBEHANDLINGSTID = Period.parse(SAKSBEHANDLINGSTID);


### PR DESCRIPTION
### Bakgrunn
Forventet saksbehanlingstid for pleiepenger har økt fra fire uker til fem. Det har blitt oppdatert på nav.no, men må også oppdateres i brevet om forlenget saksbehandlingstid.