### PR TITLE
Småpirk feilmeldinger for frontend

### DIFF
--- a/soknad/src/main/java/no/nav/k9/søknad/felles/Feil.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/felles/Feil.java
@@ -54,7 +54,7 @@ public class Feil {
             feilmelding = feilkodeMatcher.group(2).trim();
         } else if (constraintMessage.equals("must not be null")){
             feilkode = "nullFeil";
-            feilmelding = "Feltet kan ikke være tomt, null feil";
+            feilmelding = "Feltet kan ikke være tomt";
 
         }else if (constraintMessage.equals("must not be empty")){
             feilkode = "tomFeil";

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/olp/v1/Opplæringspenger.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/olp/v1/Opplæringspenger.java
@@ -142,7 +142,7 @@ public class Opplæringspenger implements Ytelse {
     }
 
     public Opplæringspenger medSøknadsperiode(Periode søknadsperiode) {
-        this.søknadsperiode.add(Objects.requireNonNull(søknadsperiode, "søknadsperiode"));
+        this.søknadsperiode.add(Objects.requireNonNull(søknadsperiode, "Søknadsperiode er påkrevd"));
         return this;
     }
 


### PR DESCRIPTION
Endrer feilmelding for manglende søknadsperioder siden den ofte kan dukke opp i frontend.
Fjerner "null feil" fra feiltekst på generell feilmelding, så ser det litt mer elegant ut i frontend