### PR TITLE
TSFF-1464: Gjør Kurs nullable for å kunne trekke perioder for opplæringspenger

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+### **Behov / Bakgrunn**
+
+### **Løsning**
+
+### **Andre endringer**

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/olp/v1/Opplæringspenger.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/olp/v1/Opplæringspenger.java
@@ -87,9 +87,8 @@ public class Opplæringspenger implements Ytelse {
     private Omsorg omsorg = new Omsorg();
 
     @Valid
-    @NotNull
-    @JsonProperty(value = "kurs", required = true)
-    private Kurs kurs = new Kurs();
+    @JsonProperty(value = "kurs")
+    private Kurs kurs = null;
 
     public Opplæringspenger() {
     }

--- a/soknad/src/main/java/no/nav/k9/søknad/ytelse/olp/v1/OpplæringspengerYtelseValidator.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/ytelse/olp/v1/OpplæringspengerYtelseValidator.java
@@ -95,11 +95,19 @@ class OpplæringspengerYtelseValidator extends YtelseValidator {
             feilene.addAll(validerAtIngenPerioderOverlapperMedTrekkKravPerioder(trekkKravPerioderTidslinje, ytelsePeriodeTidsserie, ytelsePeriode.getFelt() + ".perioder"));
         }
 
-        validerAtYtelsePeriodenErKomplettMedSøknad(søknadsperiodeTidslinje, olp.getKurs().getKursperioder(), "kurs.kursperioder", feilene);
+        if (olp.getKurs() != null) {
+            validerAtYtelsePeriodenErKomplettMedSøknad(søknadsperiodeTidslinje, olp.getKurs().getKursperioder(), "kurs.kursperioder", feilene);
 
-        validerReise(olp.getKurs().getReise(), "kurs.reise", feilene);
-        validerReisetidMotKursperioden(olp.getKurs().getKursperioder(), olp.getKurs().getReise(), "kurs.reise", feilene);
-        validerKursholder(olp.getKurs().getKursholder(), feilene);
+            validerReise(olp.getKurs().getReise(), "kurs.reise", feilene);
+            validerReisetidMotKursperioden(olp.getKurs().getKursperioder(), olp.getKurs().getReise(), "kurs.reise", feilene);
+            validerKursholder(olp.getKurs().getKursholder(), feilene);
+        } else {
+            validerAtYtelsePeriodenErKomplettMedSøknad(søknadsperiodeTidslinje, List.of(), "kurs.kursperioder", feilene);
+
+            if (trekkKravPerioderTidslinje.isEmpty()) {
+                feilene.add(lagFeil("kurs", "påkrevd", "Kurs eller trekkKravPerioder må være satt."));
+            }
+        }
 
         return feilene;
     }

--- a/soknad/src/test/java/no/nav/k9/søknad/ytelse/olp/v1/OpplæringspengerYtelseValidatorTest.java
+++ b/soknad/src/test/java/no/nav/k9/søknad/ytelse/olp/v1/OpplæringspengerYtelseValidatorTest.java
@@ -16,21 +16,87 @@ import no.nav.k9.søknad.ytelse.olp.v1.kurs.Reise;
 import no.nav.k9.søknad.ytelse.psb.YtelseEksempel;
 
 class OpplæringspengerYtelseValidatorTest {
+    private final Periode SØKNADSPERIODE = new Periode(LocalDate.now(), LocalDate.now().plusWeeks(1));
+    private final Periode GYLDIG_ENDRINGS_PERIODE = new Periode(LocalDate.now(), LocalDate.now().plusWeeks(2));
+    private final Reise REISEDAG_I_DAG = new Reise(true, List.of(LocalDate.now()), "Langt å kjøre");
+    private final Reise INGEN_REISEDAG = new Reise(false, List.of(), null);
 
     private final OpplæringspengerYtelseValidator ytelseValidator = new OpplæringspengerYtelseValidator();
 
-    private Opplæringspenger lagYtelse() {
-        Periode søknadsperiode = new Periode(LocalDate.now(), LocalDate.now().plusWeeks(1));
-        Reise reise = new Reise(true, List.of(LocalDate.now()), "Langt å kjøre");
-        Kurs kurs = new Kurs(new Kursholder(UUID.randomUUID()), List.of(søknadsperiode), reise);
-        return new Opplæringspenger().medBarn(YtelseEksempel.lagBarn()).medSøknadsperiode(List.of(søknadsperiode)).medUttak(YtelseEksempel.lagUttak(søknadsperiode)).medKurs(kurs);
-    }
-
     @Test
     void skalValidereOk() {
-        Opplæringspenger olpYtelse = lagYtelse();
+        Kurs kurs = new Kurs(new Kursholder(UUID.randomUUID()), List.of(SØKNADSPERIODE), REISEDAG_I_DAG);
+        Opplæringspenger olpYtelse = new Opplæringspenger().medBarn(YtelseEksempel.lagBarn()).medSøknadsperiode(List.of(SØKNADSPERIODE)).medUttak(YtelseEksempel.lagUttak(SØKNADSPERIODE)).medKurs(kurs);
 
         List<Feil> feil = ytelseValidator.valider(olpYtelse);
         assertThat(feil).isEmpty();
+    }
+
+    @Test
+    void KursperioderIkkeLikSøknadsperiodeSkalKasteFeil() {
+        Periode kursPeriodeSomIkkeErLikSøknadsperiode = new Periode(LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
+        Kurs kurs = new Kurs(new Kursholder(UUID.randomUUID()), List.of(kursPeriodeSomIkkeErLikSøknadsperiode), REISEDAG_I_DAG);
+
+        Opplæringspenger olpYtelse = new Opplæringspenger().medBarn(YtelseEksempel.lagBarn()).medSøknadsperiode(List.of(SØKNADSPERIODE)).medUttak(YtelseEksempel.lagUttak(SØKNADSPERIODE)).medKurs(kurs);
+
+        List<Feil> feil = ytelseValidator.valider(olpYtelse);
+        assertThat(feil.size()).isEqualTo(1);
+        assertThat(feil.get(0).getFeilmelding()).contains("Periodene er ikke komplett, periode som mangler er:");
+    }
+
+    @Test
+    void TrekkAvKravPerioderSkalVæreOk() {
+        Periode trekkKravPeriode = new Periode(GYLDIG_ENDRINGS_PERIODE.getFraOgMed(), GYLDIG_ENDRINGS_PERIODE.getFraOgMed());
+        Opplæringspenger olpYtelse = new Opplæringspenger().medBarn(YtelseEksempel.lagBarn()).medSøknadsperiode(List.of()).addTrekkKravPeriode(trekkKravPeriode);
+
+        List<Feil> feil = ytelseValidator.valider(olpYtelse, List.of(GYLDIG_ENDRINGS_PERIODE));
+        assertThat(feil).isEmpty();
+    }
+
+    @Test
+    void ManglendeKursOgTrekkVarPeriodeSkalKasteFeil() {
+        Opplæringspenger olpYtelse = new Opplæringspenger().medBarn(YtelseEksempel.lagBarn()).medSøknadsperiode(List.of());
+        List<Feil> feil = ytelseValidator.valider(olpYtelse, List.of(GYLDIG_ENDRINGS_PERIODE));
+
+        assertThat(feil.size()).isEqualTo(1);
+        assertThat(feil.get(0).getFeilmelding()).isEqualTo("Kurs eller trekkKravPerioder må være satt.");
+    }
+
+    @Test
+    void TrekkAvPeriodeOgLeggTilNyttKursIAnnenPeriodeSkalVæreOk() {
+        Periode trekkKravPeriode = new Periode(GYLDIG_ENDRINGS_PERIODE.getFraOgMed(), GYLDIG_ENDRINGS_PERIODE.getFraOgMed().plusWeeks(1));
+        Periode nyKursPeriode = new Periode(LocalDate.now().plusWeeks(3), LocalDate.now().plusWeeks(4));
+        Kurs kurs = new Kurs(new Kursholder(UUID.randomUUID()), List.of(nyKursPeriode), INGEN_REISEDAG);
+
+        Opplæringspenger olpYtelse = new Opplæringspenger().medBarn(YtelseEksempel.lagBarn()).medSøknadsperiode(List.of(nyKursPeriode)).addAllTrekkKravPerioder(List.of(trekkKravPeriode)).medKurs(kurs);
+        List<Feil> feil = ytelseValidator.valider(olpYtelse, List.of(GYLDIG_ENDRINGS_PERIODE));
+
+        assertThat(feil.size()).isEqualTo(0);
+    }
+
+    // test at trekkKravPeriode overlapper med søknadsperiode gir feil
+    @Test
+    void TrekkKravPeriodeOverlapperMedSøknadsperiodeGirFeil() {
+        Periode trekkKravPeriode = new Periode(SØKNADSPERIODE.getFraOgMed().minusDays(1), SØKNADSPERIODE.getTilOgMed().plusDays(1));
+        Kurs kurs = new Kurs(new Kursholder(UUID.randomUUID()), List.of(SØKNADSPERIODE), REISEDAG_I_DAG);
+        Opplæringspenger olpYtelse = new Opplæringspenger().medBarn(YtelseEksempel.lagBarn()).medSøknadsperiode(List.of(SØKNADSPERIODE)).addTrekkKravPeriode(trekkKravPeriode).medKurs(kurs);
+
+        List<Feil> feil = ytelseValidator.valider(olpYtelse);
+        assertThat(feil.size()).isEqualTo(1);
+        assertThat(feil.get(0).getFelt()).isEqualTo("ytelse.trekkKravPerioder");
+        assertThat(feil.get(0).getFeilmelding()).contains("Overlapper med trekk krav periode:");
+    }
+
+    @Test
+    void SøknadsperiodeUtenKursSomOverlapperTrekkKreavPeriodeGir2Feil() {
+        Periode trekkKravPeriode = new Periode(SØKNADSPERIODE.getFraOgMed().minusDays(1), SØKNADSPERIODE.getTilOgMed().plusDays(1));
+        Opplæringspenger olpYtelse = new Opplæringspenger().medBarn(YtelseEksempel.lagBarn()).medSøknadsperiode(List.of(SØKNADSPERIODE)).addTrekkKravPeriode(trekkKravPeriode);
+
+        List<Feil> feil = ytelseValidator.valider(olpYtelse);
+        assertThat(feil.size()).isEqualTo(2);
+        assertThat(feil.get(0).getFelt()).isEqualTo("ytelse.trekkKravPerioder");
+        assertThat(feil.get(0).getFeilmelding()).contains("Overlapper med trekk krav periode:");
+        assertThat(feil.get(1).getFelt()).isEqualTo("ytelse.kurs.kursperioder");
+        assertThat(feil.get(1).getFeilmelding()).contains("Periodene er ikke komplett, periode som mangler er:");
     }
 }


### PR DESCRIPTION
### **Behov / Bakgrunn**
Dersom man skal trekke periode for opplæringspenger skal det ikke være nødvendig å legge til Kurs.

### **Løsning**
Gjør Kurs nullable og legger til validering slik at Kurs kun er null dersom det finnes perioder i trekkKravPerioder inneholder minst en periode. 

### **Andre endringer**
Legger til pull request template