### PR TITLE
Endrer forlenget saksbehandlingstid til 9 uker

### DIFF
--- a/konstant/src/main/java/no/nav/k9/konstant/Konstant.java
+++ b/konstant/src/main/java/no/nav/k9/konstant/Konstant.java
@@ -3,7 +3,7 @@ package no.nav.k9.konstant;
 import java.time.Period;
 
 public class Konstant {
-    private static final String SAKSBEHANDLINGSTID = "P8W";
+    private static final String SAKSBEHANDLINGSTID = "P9W";
     private static final String UTLAND_SAKSBEHANDLINGSTID = "P6M";
 
     public static final Period FORVENTET_SAKSBEHANDLINGSTID = Period.parse(SAKSBEHANDLINGSTID);


### PR DESCRIPTION
### **Behov / Bakgrunn**
Etter ferien har saksbehandlingstiden økt til 9 uker.

### **Løsning**
Endrer konstant for saksbehandlingstid til 9 uker så vi opplyser om riktig saksbehandlingstid til brukerne våre.