### PR TITLE
TSFF-1829: Utvid ettersendelseType med KURSINFORMASJON

### DIFF
--- a/ettersendelse/src/main/java/no/nav/k9/ettersendelse/EttersendelseType.java
+++ b/ettersendelse/src/main/java/no/nav/k9/ettersendelse/EttersendelseType.java
@@ -5,5 +5,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public enum EttersendelseType {
     LEGEERKLÆRING,
+    KURSINFORMASJON,
     ANNET
 }


### PR DESCRIPTION
### **Behov / Bakgrunn**
For få ettersendt kursinformasjon direkte inn i k9-sak, må vi utvide `EttersendesleType` med `KURSINFORMASJON` som vi har i [brukerdialog](https://github.com/navikt/k9-brukerdialog-prosessering/blob/dab7460af3c9e9a1c82fe5e9e4cc76fd16c5ac27/src/main/kotlin/no/nav/brukerdialog/ytelse/oppl%C3%A6ringspenger/api/domene/EttersendingAvVedlegg.kt#L23)

### **Løsning**
Legger til samme enum som vi har i brukerdialog