### PR TITLE
Jackson 3 deserialisering krever at @JsonManagedReference har en nøst…

### DIFF
--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/OppgaveBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/OppgaveBekreftelse.java
@@ -48,7 +48,6 @@ public class OppgaveBekreftelse implements Innsending {
     @JsonProperty(value = "språk", required = false)
     private Språk språk = Språk.NORSK_BOKMÅL;
 
-    @JsonManagedReference
     @Valid
     @NotNull
     @JsonProperty(value = "bekreftelse", required = true)

--- a/soknad/src/main/java/no/nav/k9/søknad/Søknad.java
+++ b/soknad/src/main/java/no/nav/k9/søknad/Søknad.java
@@ -53,7 +53,6 @@ public class Søknad implements Innsending {
     @JsonProperty(value = "begrunnelseForInnsending")
     private BegrunnelseForInnsending begrunnelseForInnsending = new BegrunnelseForInnsending();
 
-    @JsonManagedReference
     @Valid
     @NotNull
     @JsonProperty(value = "ytelse", required = true)


### PR DESCRIPTION
…et referanse tilbake til parent til objektet som har @JsonManagedReference annotert med @JsonBackReference. Det er ikke tilfelle her da ingen av implementasjonene av Ytelse referer til Søknad og Bekreftelse referer til OppgaveBekreftelse