### PR TITLE
Lager inntektsrapportering som egen innsending

### DIFF
--- a/inntektsrapportering/pom.xml
+++ b/inntektsrapportering/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>k9-format</artifactId>
+        <groupId>no.nav.k9</groupId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>inntektsrapportering</artifactId>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>no.nav.k9</groupId>
+            <artifactId>soknad</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.k9</groupId>
+            <artifactId>konstant</artifactId>
+            <version>${revision}${sha1}${changelist}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/inntektsrapportering/src/main/java/no/nav/ung/inntektsrapportering/Inntektsrapportering.java
+++ b/inntektsrapportering/src/main/java/no/nav/ung/inntektsrapportering/Inntektsrapportering.java
@@ -1,0 +1,212 @@
+package no.nav.ung.inntektsrapportering;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import no.nav.ung.inntektsrapportering.inntekt.OppgittInntekt;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import no.nav.k9.søknad.Innsending;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.felles.DtoKonstanter;
+import no.nav.k9.søknad.felles.Kildesystem;
+import no.nav.k9.søknad.felles.Versjon;
+import no.nav.k9.søknad.felles.personopplysninger.Søker;
+import no.nav.k9.søknad.felles.type.Språk;
+import no.nav.k9.søknad.felles.type.SøknadId;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Optional;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
+public class Inntektsrapportering implements Innsending {
+
+    @Valid
+    @NotNull
+    @JsonProperty(value = "søknadId", required = true)
+    private SøknadId søknadId;
+
+    @Valid
+    @NotNull
+    @JsonProperty(value = "versjon", required = true)
+    private Versjon versjon;
+
+    @Valid
+    @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DtoKonstanter.DATO_TID_FORMAT, timezone = DtoKonstanter.TIDSSONE)
+    @JsonProperty(value = "mottattDato", required = true)
+    private ZonedDateTime mottattDato;
+
+    @Valid
+    @NotNull
+    @JsonProperty(value = "søker", required = true)
+    private Søker søker;
+
+    @Valid
+    @JsonProperty(value = "språk", required = false)
+    private Språk språk = Språk.NORSK_BOKMÅL;
+
+    @Valid
+    @NotNull
+    @JsonProperty(value = "inntekter", required = true)
+    private OppgittInntekt inntekter;
+
+    @Valid
+    @JsonProperty(value = "kildesystem", required = false)
+    private Kildesystem kildesystem;
+
+    public Inntektsrapportering() {
+        //
+    }
+
+    @JsonCreator
+    public Inntektsrapportering(@JsonProperty(value = "søknadId", required = true) @Valid @NotNull SøknadId søknadId,
+                                @JsonProperty(value = "versjon", required = true) @Valid @NotNull Versjon versjon,
+                                @JsonProperty(value = "mottattDato", required = true) @Valid @NotNull ZonedDateTime mottattDato,
+                                @JsonProperty(value = "søker", required = true) @Valid @NotNull Søker søker,
+                                @JsonProperty(value = "språk", required = false) @Valid Språk språk,
+                                @JsonProperty(value = "inntekter", required = true) @Valid @NotNull OppgittInntekt inntekter) {
+        this.søknadId = Objects.requireNonNull(søknadId, "søknadId");
+        this.versjon = Objects.requireNonNull(versjon, "versjon");
+        this.mottattDato = Objects.requireNonNull(mottattDato, "mottattDato");
+        this.søker = Objects.requireNonNull(søker, "søker");
+        this.inntekter = Objects.requireNonNull(inntekter, "inntekter");
+        this.språk = språk;
+    }
+
+    public Inntektsrapportering(@JsonProperty(value = "søknadId", required = true) @Valid @NotNull SøknadId søknadId,
+                                @JsonProperty(value = "versjon", required = true) @Valid @NotNull Versjon versjon,
+                                @JsonProperty(value = "mottattDato", required = true) @Valid @NotNull ZonedDateTime mottattDato,
+                                @JsonProperty(value = "søker", required = true) @Valid @NotNull Søker søker,
+                                @JsonProperty(value = "inntekter", required = true) @Valid @NotNull OppgittInntekt inntekter) {
+        this(søknadId, versjon, mottattDato, søker, Språk.NORSK_BOKMÅL, inntekter);
+    }
+
+    @Override
+    public SøknadId getSøknadId() {
+        return søknadId;
+    }
+
+    @Override
+    public Versjon getVersjon() {
+        return versjon;
+    }
+
+    @Override
+    public ZonedDateTime getMottattDato() {
+        return mottattDato;
+    }
+
+    public Språk getSpråk() {
+        return språk;
+    }
+
+
+    @Override
+    public Søker getSøker() {
+        return søker;
+    }
+
+    public OppgittInntekt getInntekter() {
+        return inntekter;
+    }
+
+
+    public Optional<Kildesystem> getKildesystem() {
+        return Optional.ofNullable(kildesystem);
+    }
+
+    public void setSøknadId(SøknadId søknadId) {
+        this.søknadId = Objects.requireNonNull(søknadId, "søknadId");
+    }
+
+    public void setVersjon(Versjon versjon) {
+        this.versjon = Objects.requireNonNull(versjon);
+    }
+
+    public void setMottattDato(ZonedDateTime mottattDato) {
+        this.mottattDato = Objects.requireNonNull(mottattDato, "mottattDato");
+    }
+
+    public void setSøker(Søker søker) {
+        this.søker = Objects.requireNonNull(søker, "søker");
+    }
+
+    public void setInntekter(OppgittInntekt inntekter) {
+        this.inntekter = Objects.requireNonNull(inntekter, "inntekter");
+    }
+
+    public void setKildesystem(Kildesystem kildesystem) {
+        this.kildesystem = kildesystem;
+    }
+
+    public Inntektsrapportering medMottattDato(ZonedDateTime mottattDato) {
+        this.mottattDato = Objects.requireNonNull(mottattDato, "mottattDato");
+        return this;
+    }
+
+    public Inntektsrapportering medSpråk(Språk språk) {
+        this.språk = språk;
+        return this;
+    }
+
+    public Inntektsrapportering medSøknadId(String søknadId) {
+        this.søknadId = new SøknadId(Objects.requireNonNull(søknadId, "søknadId"));
+        return this;
+    }
+
+    public Inntektsrapportering medSøknadId(SøknadId søknadId) {
+        this.søknadId = Objects.requireNonNull(søknadId, "søknadId");
+        return this;
+    }
+
+    public Inntektsrapportering medVersjon(String versjon) {
+        this.versjon = new Versjon(Objects.requireNonNull(versjon, "versjon"));
+        return this;
+    }
+
+    public Inntektsrapportering medVersjon(Versjon versjon) {
+        this.versjon = Objects.requireNonNull(versjon, "versjon");
+        return this;
+    }
+
+    public Inntektsrapportering medSøker(Søker søker) {
+        this.søker = Objects.requireNonNull(søker, "søker");
+        return this;
+    }
+
+    public Inntektsrapportering medInntekter(OppgittInntekt inntekter) {
+        this.inntekter = Objects.requireNonNull(inntekter, "inntekter");
+        return this;
+    }
+
+
+    public Inntektsrapportering medKildesystem(Kildesystem kildesystem) {
+        this.kildesystem = kildesystem;
+        return this;
+    }
+
+    public static final class SerDes {
+        private SerDes() {
+        }
+
+        public static String serialize(Inntektsrapportering inntektsrapportering) {
+            return JsonUtils.toString(inntektsrapportering);
+        }
+
+        public static Inntektsrapportering deserialize(String inntektsrapportering) {
+            return JsonUtils.fromString(inntektsrapportering, Inntektsrapportering.class);
+        }
+
+        public static Inntektsrapportering deserialize(ObjectNode node) {
+            try {
+                return JsonUtils.getObjectMapper().treeToValue(node, Inntektsrapportering.class);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Kunne ikke konvertere til Oppgave.class", e);
+            }
+        }
+
+    }
+}

--- a/inntektsrapportering/src/main/java/no/nav/ung/inntektsrapportering/inntekt/OppgittInntekt.java
+++ b/inntektsrapportering/src/main/java/no/nav/ung/inntektsrapportering/inntekt/OppgittInntekt.java
@@ -1,0 +1,90 @@
+package no.nav.ung.inntektsrapportering.inntekt;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import no.nav.k9.søknad.felles.type.Periode;
+
+import java.time.LocalDate;
+import java.util.*;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
+public class OppgittInntekt {
+
+    /**
+     * Inntekter i periode som arbeidstaker og/eller frilans
+     */
+    @JsonProperty(value = "oppgittePeriodeinntekter")
+    @NotNull
+    @Size(min = 1)
+    private NavigableSet<@Valid @NotNull OppgittInntektForPeriode> oppgittePeriodeinntekter;
+
+    @JsonCreator
+    public OppgittInntekt(@JsonProperty(value = "oppgittePeriodeinntekter") Set<OppgittInntektForPeriode> oppgittePeriodeinntekter) {
+        this.oppgittePeriodeinntekter = (oppgittePeriodeinntekter == null) ? Collections.emptyNavigableSet()
+                : Collections.unmodifiableNavigableSet(new TreeSet<>(oppgittePeriodeinntekter));
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public NavigableSet<OppgittInntektForPeriode> getOppgittePeriodeinntekter() {
+        return oppgittePeriodeinntekter;
+    }
+
+    public Periode getMinMaksPeriode() {
+        final var first = oppgittePeriodeinntekter.first();
+        final var last = oppgittePeriodeinntekter.last();
+        return new Periode(first.getPeriode().getFraOgMed(), last.getPeriode().getTilOgMed());
+    }
+
+    public static final class Builder {
+        private Set<OppgittInntektForPeriode> oppgittePeriodeinntekter = new LinkedHashSet<>();
+
+        private Builder() {
+        }
+
+        public Builder medOppgittePeriodeinntekter(Set<OppgittInntektForPeriode> inntekter) {
+            if (inntekter != null) {
+                oppgittePeriodeinntekter.addAll(inntekter);
+            }
+            return this;
+        }
+
+        public OppgittInntekt build() {
+            if (oppgittePeriodeinntekter.isEmpty()) {
+                throw new IllegalStateException("Må oppgi minst en periodeinntekt");
+            }
+            return new OppgittInntekt(oppgittePeriodeinntekter);
+        }
+    }
+
+    @AssertTrue(message = "Perioder for inntekt kan ikke overlappe")
+    public boolean isHarIngenOverlappendePerioder() {
+        return harIngenOverlapp(oppgittePeriodeinntekter);
+    }
+
+    private boolean harIngenOverlapp(@Valid @NotNull NavigableSet<@NotNull OppgittInntektForPeriode> set) {
+        final var iterator = set.iterator();
+        // Initialiserer til første mulige periode
+        var prev = new Periode(LocalDate.MIN, LocalDate.MIN);
+        // Siden settet er av typen NavigableSet (sortert) trenger vi kun å sjekke forrige element i lista
+        while (iterator.hasNext()) {
+            final var next = iterator.next();
+            if (!prev.getTilOgMed().isBefore(next.getPeriode().getFraOgMed())) {
+                return false;
+            }
+            prev = next.getPeriode();
+        }
+        return true;
+    }
+
+
+}

--- a/inntektsrapportering/src/main/java/no/nav/ung/inntektsrapportering/inntekt/OppgittInntektForPeriode.java
+++ b/inntektsrapportering/src/main/java/no/nav/ung/inntektsrapportering/inntekt/OppgittInntektForPeriode.java
@@ -1,0 +1,91 @@
+package no.nav.ung.inntektsrapportering.inntekt;
+
+import com.fasterxml.jackson.annotation.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import no.nav.k9.søknad.felles.type.Periode;
+import no.nav.k9.søknad.felles.validering.periode.GyldigPeriode;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
+public class OppgittInntektForPeriode implements Comparable<OppgittInntektForPeriode> {
+
+    private static final String MIN = "0.00";
+    private static final String MAX = "10000000.00";
+
+    @JsonProperty(value = "periode", required = true)
+    @Valid
+    @NotNull
+    @GyldigPeriode(krevFomDato = true, krevTomDato = true)
+    private Periode periode;
+
+    @JsonProperty(value = "arbeidstakerOgFrilansInntekt", required = false)
+    @Valid
+    @DecimalMin(MIN)
+    @DecimalMax(MAX)
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private BigDecimal arbeidstakerOgFrilansInntekt;
+
+
+    @JsonCreator
+    public OppgittInntektForPeriode(@JsonProperty(value = "arbeidstakerOgFrilansInntekt") BigDecimal arbeidstakerOgFrilansInntekt,
+                                    @JsonProperty(value = "periode") Periode periode) {
+        this.arbeidstakerOgFrilansInntekt = arbeidstakerOgFrilansInntekt;
+        this.periode = periode;
+    }
+
+    public static Builder builder(Periode periode) {
+        return new Builder(periode);
+    }
+
+    public Periode getPeriode() {
+        return periode;
+    }
+
+    public BigDecimal getArbeidstakerOgFrilansInntekt() {
+        return arbeidstakerOgFrilansInntekt;
+    }
+
+    @Override
+    public int compareTo(OppgittInntektForPeriode o) {
+        return this.periode.compareTo(o.periode);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        OppgittInntektForPeriode that = (OppgittInntektForPeriode) o;
+        return Objects.equals(periode, that.periode) &&
+                Objects.equals(arbeidstakerOgFrilansInntekt, that.arbeidstakerOgFrilansInntekt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(periode, arbeidstakerOgFrilansInntekt);
+    }
+
+    public static final class Builder {
+        private BigDecimal arbeidstakerOgFrilansInntekt;
+        private Periode periode;
+
+        private Builder(Periode periode) {
+            this.periode = periode;
+        }
+
+        public Builder medArbeidstakerOgFrilansinntekt(BigDecimal inntekt) {
+            this.arbeidstakerOgFrilansInntekt = inntekt;
+            return this;
+        }
+
+
+        public OppgittInntektForPeriode build() {
+            return new OppgittInntektForPeriode(arbeidstakerOgFrilansInntekt, periode);
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>ettersendelse</module>
         <module>konstant</module>
         <module>oppgave-ungdomsytelse</module>
+        <module>inntektsrapportering</module>
     </modules>
 
     <properties>
@@ -94,6 +95,11 @@
             <dependency>
                 <groupId>no.nav.k9</groupId>
                 <artifactId>oppgave-ungdomsytelse</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>no.nav.ung</groupId>
+                <artifactId>inntektsrapportering</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi ønsker å kunne bruke samme kontrakt for inntektsrapportering for både ungdomsprogramytelsen og aktivitetspenger. Det passer også bedre inn som ein eigen innsending sidan det ikkje er ein søknad om ytelse, men tilleggsopplysninger
