### PR TITLE
Legg til sif-code-scan i CI

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -23,3 +23,9 @@ jobs:
         run: mvn verify --settings .github/settings.xml -DtrimStackTrace=false
         env:
           GITHUB_TOKEN: ${{ secrets.READER_TOKEN }}
+
+  sif-code-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -27,5 +27,6 @@ jobs:
   sif-code-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -28,5 +28,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@v1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,5 +32,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@v1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,5 +31,6 @@ jobs:
   sif-code-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.READER_TOKEN }}
           
+
+  sif-code-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/søknad/ytelse/omsorgspenger/utvidetrett/OmsorgspengerKroniskSyktBarnValidatorTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/søknad/ytelse/omsorgspenger/utvidetrett/OmsorgspengerKroniskSyktBarnValidatorTest.java
@@ -106,7 +106,7 @@ public class OmsorgspengerKroniskSyktBarnValidatorTest {
                     .medSøknadId("222e4a87-f471-4181-9d5b-7d67d046b031")
                     .medMottattDato(ZonedDateTime.now())
                     .medVersjon("1.0.0")
-                    .medSøker(new Søker(NorskIdentitetsnummer.of("02119970078")))
+                    .medSøker(new Søker(NorskIdentitetsnummer.of("24420167209")))
                     .medYtelse(new OmsorgspengerKroniskSyktBarn()
                             .medKroniskEllerFunksjonshemming(true)
                             .medBarn(barn));
@@ -118,7 +118,7 @@ public class OmsorgspengerKroniskSyktBarnValidatorTest {
                     .medSøknadId("222e4a87-f471-4181-9d5b-7d67d046b031")
                     .medMottattDato(ZonedDateTime.now())
                     .medVersjon("1.0.0")
-                    .medSøker(new Søker(NorskIdentitetsnummer.of("02119970078")))
+                    .medSøker(new Søker(NorskIdentitetsnummer.of("24420167209")))
                     .medYtelse(new OmsorgspengerKroniskSyktBarn(barn, true, true, beskrivelse));
         }
     }

--- a/soknad-jackson2og3-tester/src/test/resources/ytelse/omp/utbetaling/v1.0.0/komplett-søknad-omp-utbetaling-snf.json
+++ b/soknad-jackson2og3-tester/src/test/resources/ytelse/omp/utbetaling/v1.0.0/komplett-søknad-omp-utbetaling-snf.json
@@ -4,13 +4,13 @@
   "versjon": "1.0.0",
   "språk": "nb",
   "søker": {
-    "norskIdentitetsnummer": "02119970078"
+    "norskIdentitetsnummer": "24420167209"
   },
   "ytelse": {
     "type": "OMP_UT",
     "fosterbarn": [
       {
-        "norskIdentitetsnummer": "02119970078",
+        "norskIdentitetsnummer": "24420167209",
         "fødselsdato": null
       }
     ],

--- a/soknad-jackson2og3-tester/src/test/resources/ytelse/omp/utbetaling/v1.0.0/minimum-søknad-omp-utbetaling-snf.json
+++ b/soknad-jackson2og3-tester/src/test/resources/ytelse/omp/utbetaling/v1.0.0/minimum-søknad-omp-utbetaling-snf.json
@@ -4,7 +4,7 @@
   "versjon": "1.0.0",
   "språk": "nb",
   "søker": {
-    "norskIdentitetsnummer": "02119970078"
+    "norskIdentitetsnummer": "24420167209"
   },
   "ytelse": {
     "type": "OMP_UT",

--- a/soknad-jackson2og3-tester/src/test/resources/ytelse/omp/utbetaling/v1.1.0/komplett-søknad-omp-utbetaling-snf.json
+++ b/soknad-jackson2og3-tester/src/test/resources/ytelse/omp/utbetaling/v1.1.0/komplett-søknad-omp-utbetaling-snf.json
@@ -4,13 +4,13 @@
   "versjon": "1.1.0",
   "språk": "nb",
   "søker": {
-    "norskIdentitetsnummer": "02119970078"
+    "norskIdentitetsnummer": "24420167209"
   },
   "ytelse": {
     "type": "OMP_UT",
     "fosterbarn": [
       {
-        "norskIdentitetsnummer": "02119970078",
+        "norskIdentitetsnummer": "24420167209",
         "fødselsdato": null
       }
     ],

--- a/soknad-jackson2og3-tester/src/test/resources/ytelse/omp/utbetaling/v1.1.0/minimum-søknad-omp-utbetaling-snf.json
+++ b/soknad-jackson2og3-tester/src/test/resources/ytelse/omp/utbetaling/v1.1.0/minimum-søknad-omp-utbetaling-snf.json
@@ -4,7 +4,7 @@
   "versjon": "1.0.0",
   "språk": "nb",
   "søker": {
-    "norskIdentitetsnummer": "02119970078"
+    "norskIdentitetsnummer": "24420167209"
   },
   "ytelse": {
     "type": "OMP_UT",

--- a/soknad-omsorgspenger-utbetaling/src/test/java/no/nav/k9/søknad/omsorgspenger/utbetaling/arbeidstaker/TestUtils.java
+++ b/soknad-omsorgspenger-utbetaling/src/test/java/no/nav/k9/søknad/omsorgspenger/utbetaling/arbeidstaker/TestUtils.java
@@ -42,7 +42,7 @@ class TestUtils {
         return OmsorgspengerUtbetalingSøknad
                 .builder()
                 .søker(new Søker(NorskIdentitetsnummer.of("11111111111")))
-                .fosterbarn(new Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("11111111113")))
+                .fosterbarn(new Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("24420167209")))
                 .fosterbarn(new Barn().medFødselsdato(LocalDate.parse("2000-01-01")))
                 .mottattDato(ZonedDateTime.parse("2019-10-20T07:15:36.124Z"))
                 .søknadId(SøknadId.of("123-123-123"));

--- a/soknad-omsorgspenger-utbetaling/src/test/java/no/nav/k9/søknad/omsorgspenger/utbetaling/snf/TestUtils.java
+++ b/soknad-omsorgspenger-utbetaling/src/test/java/no/nav/k9/søknad/omsorgspenger/utbetaling/snf/TestUtils.java
@@ -82,7 +82,7 @@ class TestUtils {
                         .medStartdato(LocalDate.parse("2019-01-01"))
                         .medSluttdato(LocalDate.parse("2020-01-01")))
                 .søker(new Søker(NorskIdentitetsnummer.of("11111111111")))
-                .fosterbarn(new Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("11111111113")))
+                .fosterbarn(new Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("24420167209")))
                 .fosterbarn(new Barn().medFødselsdato(LocalDate.parse("2000-01-01")))
                 .mottattDato(ZonedDateTime.parse("2019-10-20T07:15:36.124Z"))
                 .søknadId(SøknadId.of("123-123-123"));
@@ -115,7 +115,7 @@ class TestUtils {
                 .frilanser(new Frilanser()
                         .medStartdato(LocalDate.parse("2019-01-01")))
                 .søker(new Søker(NorskIdentitetsnummer.of("11111111111")))
-                .fosterbarn(new Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("11111111113")))
+                .fosterbarn(new Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of("24420167209")))
                 .fosterbarn(new Barn().medFødselsdato(LocalDate.parse("2000-01-01")))
                 .mottattDato(ZonedDateTime.parse("2019-10-20T07:15:36.124Z"))
                 .søknadId(SøknadId.of("123-123-123"));

--- a/soknad-omsorgspenger-utbetaling/src/test/resources/arbeidstaker/komplett-søknad-med-barn.json
+++ b/soknad-omsorgspenger-utbetaling/src/test/resources/arbeidstaker/komplett-søknad-med-barn.json
@@ -7,7 +7,7 @@
   },
   "barn": [
     {
-      "norskIdentitetsnummer": "11111111113",
+      "norskIdentitetsnummer": "24420167209",
       "fødselsdato": null
     },
     {

--- a/soknad-omsorgspenger-utbetaling/src/test/resources/arbeidstaker/komplett-søknad.json
+++ b/soknad-omsorgspenger-utbetaling/src/test/resources/arbeidstaker/komplett-søknad.json
@@ -7,7 +7,7 @@
   },
   "fosterbarn": [
     {
-      "norskIdentitetsnummer": "11111111113",
+      "norskIdentitetsnummer": "24420167209",
       "fødselsdato": null
     },
     {

--- a/soknad-omsorgspenger-utbetaling/src/test/resources/snf/komplett-søknad-med-barn.json
+++ b/soknad-omsorgspenger-utbetaling/src/test/resources/snf/komplett-søknad-med-barn.json
@@ -6,7 +6,7 @@
     "norskIdentitetsnummer": "11111111111"
   },
   "barn": [{
-    "norskIdentitetsnummer": "11111111113",
+    "norskIdentitetsnummer": "24420167209",
     "fødselsdato": null
   }, {
     "norskIdentitetsnummer": null,

--- a/soknad-omsorgspenger-utbetaling/src/test/resources/snf/komplett-søknad-uten-næringsinntekt.json
+++ b/soknad-omsorgspenger-utbetaling/src/test/resources/snf/komplett-søknad-uten-næringsinntekt.json
@@ -6,7 +6,7 @@
     "norskIdentitetsnummer": "11111111111"
   },
   "fosterbarn": [{
-    "norskIdentitetsnummer": "11111111113",
+    "norskIdentitetsnummer": "24420167209",
     "fødselsdato": null
   }, {
     "norskIdentitetsnummer": null,

--- a/soknad-omsorgspenger-utbetaling/src/test/resources/snf/komplett-søknad.json
+++ b/soknad-omsorgspenger-utbetaling/src/test/resources/snf/komplett-søknad.json
@@ -6,7 +6,7 @@
     "norskIdentitetsnummer": "11111111111"
   },
   "fosterbarn": [{
-    "norskIdentitetsnummer": "11111111113",
+    "norskIdentitetsnummer": "24420167209",
     "fødselsdato": null
   }, {
     "norskIdentitetsnummer": null,


### PR DESCRIPTION
Legger til sif-code-scan som en parallell jobb i CI-workflowen. Denne sjekker koden for sensitive data som fødselsnummer.