### PR TITLE
TSFF-2654: Ny kontrakt for bekreftelse av automatisk opphør

### DIFF
--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/Bekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/Bekreftelse.java
@@ -1,12 +1,12 @@
 package no.nav.k9.oppgave.bekreftelse;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.validation.Valid;
 import no.nav.k9.oppgave.bekreftelse.ung.bosatt.BostedAvklaringBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.opphor.AutomatiskOpphørBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretPeriodeBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretSluttdatoBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretStartdatoBekreftelse;
@@ -24,8 +24,8 @@ import java.util.UUID;
         @JsonSubTypes.Type(name = Bekreftelse.UNG_FJERNET_PERIODE, value = FjernetPeriodeBekreftelse.class),
         @JsonSubTypes.Type(name = Bekreftelse.UNG_AVVIK_REGISTERINNTEKT, value = InntektBekreftelse.class),
         @JsonSubTypes.Type(name = Bekreftelse.AVP_BOSTED_AVKLARING, value = BostedAvklaringBekreftelse.class),
+        @JsonSubTypes.Type(name = Bekreftelse.UNG_AUTOMATISK_OPPHOR, value = AutomatiskOpphørBekreftelse.class),
 })
-@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
 public interface Bekreftelse {
 
     String UNG_ENDRET_STARTDATO = "UNG_ENDRET_STARTDATO";
@@ -34,6 +34,7 @@ public interface Bekreftelse {
     String UNG_FJERNET_PERIODE = "UNG_FJERNET_PERIODE";
     String UNG_AVVIK_REGISTERINNTEKT = "UNG_AVVIK_REGISTERINNTEKT";
     String AVP_BOSTED_AVKLARING = "AVP_BOSTED_AVKLARING";
+    String UNG_AUTOMATISK_OPPHOR = "UNG_AUTOMATISK_OPPHOR";
 
     /**
      * Unik id for oppgaven som blir bekreftet
@@ -60,7 +61,8 @@ public interface Bekreftelse {
         UNG_ENDRET_PERIODE(Bekreftelse.UNG_ENDRET_PERIODE),
         UNG_FJERNET_PERIODE(Bekreftelse.UNG_FJERNET_PERIODE),
         UNG_AVVIK_REGISTERINNTEKT(Bekreftelse.UNG_AVVIK_REGISTERINNTEKT),
-        AVP_BOSTED_AVKLARING(Bekreftelse.AVP_BOSTED_AVKLARING);
+        AVP_BOSTED_AVKLARING(Bekreftelse.AVP_BOSTED_AVKLARING),
+        UNG_AUTOMATISK_OPPHOR(Bekreftelse.UNG_AUTOMATISK_OPPHOR);
 
 
         @JsonValue

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/opphor/AutomatiskOpphørBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/opphor/AutomatiskOpphørBekreftelse.java
@@ -1,0 +1,73 @@
+package no.nav.k9.oppgave.bekreftelse.ung.opphor;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import no.nav.k9.konstant.Patterns;
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Bekreftelse fra bruker ved automatisk opphør av ungdomsprogramytelsen.
+ * Bruker kan bekrefte at de har lest varselet, eventuelt med en kommentar.
+ *
+ * <p>Merk: {@code @JsonIgnoreProperties("type")} er nødvendig fordi {@link Bekreftelse}-interfacet
+ * bruker {@code @JsonTypeInfo(As.PROPERTY)}, og Jackson 2 lekker typediscriminatoren inn i
+ * record-deserialiseringen i stedet for å konsumere den sentralt. Jackson 3 håndterer dette korrekt
+ * uten annotasjonen.
+ */
+@com.fasterxml.jackson.annotation.JsonIgnoreProperties("type")
+public record AutomatiskOpphørBekreftelse(
+        UUID oppgaveReferanse,
+        LocalDate sluttdato,
+        boolean harUttalelse,
+        @Pattern(regexp = Patterns.FRITEKST, message = "[ugyldigSyntaks] matcher ikke tillatt pattern [{regexp}]")
+        @Size(max = 4000)
+        String uttalelseFraBruker,
+        DataBruktTilUtledning dataBruktTilUtledning
+) implements Bekreftelse {
+
+    public AutomatiskOpphørBekreftelse(UUID oppgaveReferanse, LocalDate sluttdato, boolean harUttalelse) {
+        this(oppgaveReferanse, sluttdato, harUttalelse, null, null);
+    }
+
+    @Override
+    public UUID getOppgaveReferanse() {
+        return oppgaveReferanse;
+    }
+
+    public LocalDate getSluttdato() {
+        return sluttdato;
+    }
+
+    @Override
+    public boolean harUttalelse() {
+        return harUttalelse;
+    }
+
+    @Override
+    public String getUttalelseFraBruker() {
+        return uttalelseFraBruker;
+    }
+
+    @Override
+    public DataBruktTilUtledning getDataBruktTilUtledning() {
+        return dataBruktTilUtledning;
+    }
+
+    @Override
+    public Type getType() {
+        return Type.UNG_AUTOMATISK_OPPHOR;
+    }
+
+    @Override
+    public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
+        return new AutomatiskOpphørBekreftelse(oppgaveReferanse, sluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
+    }
+
+    public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
+        return new AutomatiskOpphørBekreftelse(oppgaveReferanse, sluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
+    }
+}

--- a/soknad-jackson2og3-tester/pom.xml
+++ b/soknad-jackson2og3-tester/pom.xml
@@ -22,6 +22,11 @@
             <artifactId>soknad-jackson3</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>no.nav.k9</groupId>
+            <artifactId>oppgave-ungdomsytelse</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/AutomatiskOpphørBekreftelseTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/AutomatiskOpphørBekreftelseTest.java
@@ -1,0 +1,86 @@
+package no.nav.k9.oppgave;
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.opphor.AutomatiskOpphørBekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AutomatiskOpphørBekreftelseTest {
+
+    @Test
+    void roundtrip_uten_valgfrie_felter() {
+        var original = new AutomatiskOpphørBekreftelse(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                LocalDate.of(2026, 5, 12),
+                true);
+
+        String json = JsonUtils.toString(original);
+        var roundtrip = (AutomatiskOpphørBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
+
+        assertThat(roundtrip).isEqualTo(original);
+        assertThat(roundtrip.getType()).isEqualTo(Bekreftelse.Type.UNG_AUTOMATISK_OPPHOR);
+        assertThat(roundtrip.getOppgaveReferanse()).isEqualTo(original.oppgaveReferanse());
+        assertThat(roundtrip.getSluttdato()).isEqualTo(original.sluttdato());
+        assertThat(roundtrip.harUttalelse()).isTrue();
+    }
+
+    @Test
+    void roundtrip_med_uttalelse_og_dataBruktTilUtledning() {
+        var original = new AutomatiskOpphørBekreftelse(
+                UUID.fromString("00000000-0000-0000-0000-000000000002"),
+                LocalDate.of(2026, 5, 12),
+                true)
+                .medUttalelseFraBruker("Jeg er uenig i dette vedtaket");
+
+        var medData = original.medDataBruktTilUtledning(
+                new DataBruktTilUtledning()
+                        .medHarBekreftetOpplysninger(true)
+                        .medHarForståttRettigheterOgPlikter(true));
+
+        String json = JsonUtils.toString(medData);
+        var roundtrip = (AutomatiskOpphørBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
+
+        assertThat(roundtrip.oppgaveReferanse()).isEqualTo(UUID.fromString("00000000-0000-0000-0000-000000000002"));
+        assertThat(roundtrip.sluttdato()).isEqualTo(LocalDate.of(2026, 5, 12));
+        assertThat(roundtrip.harUttalelse()).isTrue();
+        assertThat(roundtrip.getUttalelseFraBruker()).isEqualTo("Jeg er uenig i dette vedtaket");
+        assertThat(roundtrip.getDataBruktTilUtledning()).isNotNull();
+        assertThat(roundtrip.getDataBruktTilUtledning().getHarBekreftetOpplysninger()).isTrue();
+    }
+
+    @Test
+    void json_inneholder_forventede_feltnavn() {
+        var bekreftelse = new AutomatiskOpphørBekreftelse(
+                UUID.fromString("00000000-0000-0000-0000-000000000003"),
+                LocalDate.of(2026, 1, 31),
+                false);
+
+        String json = JsonUtils.toString(bekreftelse);
+
+        assertThat(json).contains("\"oppgaveReferanse\"");
+        assertThat(json).contains("\"sluttdato\"");
+        assertThat(json).contains("\"harUttalelse\"");
+    }
+
+    @Test
+    void med_metoder_gir_ny_instans_og_muterer_ikke_original() {
+        var original = new AutomatiskOpphørBekreftelse(
+                UUID.fromString("00000000-0000-0000-0000-000000000004"),
+                LocalDate.of(2026, 6, 1),
+                false);
+
+        var medUttalelse = (AutomatiskOpphørBekreftelse) original.medUttalelseFraBruker("kommentar");
+        var medData = (AutomatiskOpphørBekreftelse) original.medDataBruktTilUtledning(new DataBruktTilUtledning());
+
+        assertThat(original.getUttalelseFraBruker()).isNull();
+        assertThat(original.getDataBruktTilUtledning()).isNull();
+        assertThat(medUttalelse.getUttalelseFraBruker()).isEqualTo("kommentar");
+        assertThat(medData.getDataBruktTilUtledning()).isNotNull();
+    }
+}


### PR DESCRIPTION
### Behov / Bakgrunn

Når ungdomsprogramytelsen nærmer seg max-dato (260/300 virkedager) skal deltaker varsles og gis mulighet til å gi kommentar før ytelsen automatisk opphører. Det trengs en ny kontrakttype i k9-format som representerer deltakerens svar/bekreftelse på dette varselet.

Relatert: TSFF-2659

### Løsning

Ny bekreftelsestype `UNG_AUTOMATISK_OPPHOR` lagt til i `oppgave-ungdomsytelse`-modulen:

- Ny klasse `AutomatiskOpphørBekreftelse` under `no.nav.k9.oppgave.bekreftelse.ung.opphor`
- Registrert som `@JsonSubTypes.Type` i `Bekreftelse`-interfacet
- Ny enum-verdi `UNG_AUTOMATISK_OPPHOR` i `Bekreftelse.Type`

**Felter:**
| Felt | Type | Beskrivelse |
|------|------|-------------|
| `oppgaveReferanse` | UUID | Referanse til oppgaven som bekreftes |
| `sluttdato` | LocalDate | Opphørsdatoen |
| `harUttalelse` | boolean | Om bruker har gitt kommentar |
| `uttalelseFraBruker` | String | Valgfri kommentar fra bruker (maks 4000 tegn) |

### Andre endringer

Ingen.