### PR TITLE
Fiks oppgavebekreftelse-kontrakt: records uten duplisert type-felt

### DIFF
--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/Bekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/Bekreftelse.java
@@ -1,5 +1,6 @@
 package no.nav.k9.oppgave.bekreftelse;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -41,6 +42,7 @@ public interface Bekreftelse {
      */
     UUID getOppgaveReferanse();
 
+    @JsonIgnore
     Bekreftelse.Type getType();
 
     /**

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/opphor/AutomatiskOpphørBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/opphor/AutomatiskOpphørBekreftelse.java
@@ -63,6 +63,8 @@ public record AutomatiskOpphørBekreftelse(
     }
 
     @Override
+    // TODO(rydd): Vurder å gi denne metoden et mindre builder-liknende navn (f.eks. kloneMedDataBruktTilUtledning)
+    // siden dette i record er en kopimetode ("wither") som returnerer ny instans, ikke en muterende setter.
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
         return new AutomatiskOpphørBekreftelse(oppgaveReferanse, sluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretPeriodeBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretPeriodeBekreftelse.java
@@ -1,7 +1,7 @@
 package no.nav.k9.oppgave.bekreftelse.ung.periodeendring;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -12,35 +12,19 @@ import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 
 import java.util.UUID;
 
-public class EndretPeriodeBekreftelse implements Bekreftelse{
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EndretPeriodeBekreftelse(
+        @NotNull UUID oppgaveReferanse,
+        Periode nyPeriode,
+        @NotNull boolean harUttalelse,
+        @Pattern(regexp = Patterns.FRITEKST, message = "[ugyldigSyntaks] matcher ikke tillatt pattern [{regexp}]")
+        @Size(max = 4000)
+        String uttalelseFraBruker,
+        DataBruktTilUtledning dataBruktTilUtledning
+) implements Bekreftelse {
 
-    @NotNull
-    @JsonProperty("oppgaveReferanse")
-    private UUID oppgaveReferanse;
-
-    @JsonProperty("nyPeriode")
-    private Periode nyPeriode;
-
-    @NotNull
-    @JsonProperty("harUttalelse")
-    private boolean harUttalelse;
-
-    @JsonProperty("uttalelseFraBruker")
-    @Pattern(regexp = Patterns.FRITEKST, message = "[ugyldigSyntaks] matcher ikke tillatt pattern [{regexp}]")
-    @Size(max = 4000)
-    private String uttalelseFraBruker;
-
-    @JsonProperty("dataBruktTilUtledning")
-    private DataBruktTilUtledning dataBruktTilUtledning;
-
-    @JsonCreator
-    public EndretPeriodeBekreftelse(
-            @JsonProperty("oppgaveReferanse") UUID oppgaveReferanse,
-            @JsonProperty("nyPeriode") Periode nyPeriode,
-            @JsonProperty("harUttalelse") boolean harUttalelse) {
-        this.oppgaveReferanse = oppgaveReferanse;
-        this.nyPeriode = nyPeriode;
-        this.harUttalelse = harUttalelse;
+    public EndretPeriodeBekreftelse(UUID oppgaveReferanse, Periode nyPeriode, boolean harUttalelse) {
+        this(oppgaveReferanse, nyPeriode, harUttalelse, null, null);
     }
 
     public Periode getNyPeriode() {
@@ -52,6 +36,7 @@ public class EndretPeriodeBekreftelse implements Bekreftelse{
         return oppgaveReferanse;
     }
 
+    @JsonIgnore
     @Override
     public Bekreftelse.Type getType() {
         return Bekreftelse.Type.UNG_ENDRET_PERIODE;
@@ -64,8 +49,7 @@ public class EndretPeriodeBekreftelse implements Bekreftelse{
 
     @Override
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
-        this.dataBruktTilUtledning = dataBruktTilUtledning;
-        return this;
+        return new EndretPeriodeBekreftelse(oppgaveReferanse, nyPeriode, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 
     @Override
@@ -74,12 +58,6 @@ public class EndretPeriodeBekreftelse implements Bekreftelse{
     }
 
     public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
-        this.uttalelseFraBruker = uttalelseFraBruker;
-        return this;
-    }
-
-    @Override
-    public boolean harUttalelse() {
-        return harUttalelse;
+        return new EndretPeriodeBekreftelse(oppgaveReferanse, nyPeriode, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretPeriodeBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretPeriodeBekreftelse.java
@@ -48,6 +48,8 @@ public record EndretPeriodeBekreftelse(
     }
 
     @Override
+    // TODO(rydd): Vurder å gi denne metoden et mindre builder-liknende navn (f.eks. kloneMedDataBruktTilUtledning)
+    // siden dette i record er en kopimetode ("wither") som returnerer ny instans, ikke en muterende setter.
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
         return new EndretPeriodeBekreftelse(oppgaveReferanse, nyPeriode, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretPeriodeBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretPeriodeBekreftelse.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 public record EndretPeriodeBekreftelse(
         @NotNull UUID oppgaveReferanse,
         Periode nyPeriode,
-        @NotNull boolean harUttalelse,
+        boolean harUttalelse,
         @Pattern(regexp = Patterns.FRITEKST, message = "[ugyldigSyntaks] matcher ikke tillatt pattern [{regexp}]")
         @Size(max = 4000)
         String uttalelseFraBruker,

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretSluttdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretSluttdatoBekreftelse.java
@@ -47,6 +47,8 @@ public record EndretSluttdatoBekreftelse(
     }
 
     @Override
+    // TODO(rydd): Vurder å gi denne metoden et mindre builder-liknende navn (f.eks. kloneMedDataBruktTilUtledning)
+    // siden dette i record er en kopimetode ("wither") som returnerer ny instans, ikke en muterende setter.
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
         return new EndretSluttdatoBekreftelse(oppgaveReferanse, nySluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretSluttdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretSluttdatoBekreftelse.java
@@ -1,7 +1,7 @@
 package no.nav.k9.oppgave.bekreftelse.ung.periodeendring;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.konstant.Patterns;
@@ -11,33 +11,19 @@ import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 import java.time.LocalDate;
 import java.util.UUID;
 
-public class EndretSluttdatoBekreftelse implements Bekreftelse {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EndretSluttdatoBekreftelse(
+        UUID oppgaveReferanse,
+        LocalDate nySluttdato,
+        boolean harUttalelse,
+        @Pattern(regexp = Patterns.FRITEKST, message = "[ugyldigSyntaks] matcher ikke tillatt pattern [{regexp}]")
+        @Size(max = 4000)
+        String uttalelseFraBruker,
+        DataBruktTilUtledning dataBruktTilUtledning
+) implements Bekreftelse {
 
-    @JsonProperty("oppgaveReferanse")
-    private UUID oppgaveReferanse;
-
-    @JsonProperty("nySluttdato")
-    private LocalDate nySluttdato;
-
-    @JsonProperty("harUttalelse")
-    private boolean harUttalelse;
-
-    @JsonProperty("uttalelseFraBruker")
-    @Pattern(regexp = Patterns.FRITEKST, message = "[ugyldigSyntaks] matcher ikke tillatt pattern [{regexp}]")
-    @Size(max = 4000)
-    private String uttalelseFraBruker;
-
-    @JsonProperty("dataBruktTilUtledning")
-    private DataBruktTilUtledning dataBruktTilUtledning;
-
-    @JsonCreator
-    public EndretSluttdatoBekreftelse(
-            @JsonProperty("oppgaveReferanse") UUID oppgaveReferanse,
-            @JsonProperty("nySluttdato") LocalDate nySluttdato,
-            @JsonProperty("harUttalelse") boolean harUttalelse) {
-        this.oppgaveReferanse = oppgaveReferanse;
-        this.nySluttdato = nySluttdato;
-        this.harUttalelse = harUttalelse;
+    public EndretSluttdatoBekreftelse(UUID oppgaveReferanse, LocalDate nySluttdato, boolean harUttalelse) {
+        this(oppgaveReferanse, nySluttdato, harUttalelse, null, null);
     }
 
     public LocalDate getNySluttdato() {
@@ -49,6 +35,7 @@ public class EndretSluttdatoBekreftelse implements Bekreftelse {
         return oppgaveReferanse;
     }
 
+    @JsonIgnore
     @Override
     public Type getType() {
         return Type.UNG_ENDRET_SLUTTDATO;
@@ -61,8 +48,7 @@ public class EndretSluttdatoBekreftelse implements Bekreftelse {
 
     @Override
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
-        this.dataBruktTilUtledning = dataBruktTilUtledning;
-        return this;
+        return new EndretSluttdatoBekreftelse(oppgaveReferanse, nySluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 
     @Override
@@ -71,12 +57,6 @@ public class EndretSluttdatoBekreftelse implements Bekreftelse {
     }
 
     public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
-        this.uttalelseFraBruker = uttalelseFraBruker;
-        return this;
-    }
-
-    @Override
-    public boolean harUttalelse() {
-        return harUttalelse;
+        return new EndretSluttdatoBekreftelse(oppgaveReferanse, nySluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretStartdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretStartdatoBekreftelse.java
@@ -1,7 +1,7 @@
 package no.nav.k9.oppgave.bekreftelse.ung.periodeendring;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.konstant.Patterns;
@@ -11,33 +11,19 @@ import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 import java.time.LocalDate;
 import java.util.UUID;
 
-public class EndretStartdatoBekreftelse implements Bekreftelse {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EndretStartdatoBekreftelse(
+        UUID oppgaveReferanse,
+        LocalDate nyStartdato,
+        boolean harUttalelse,
+        @Pattern(regexp = Patterns.FRITEKST, message = "[ugyldigSyntaks] matcher ikke tillatt pattern [{regexp}]")
+        @Size(max = 4000)
+        String uttalelseFraBruker,
+        DataBruktTilUtledning dataBruktTilUtledning
+) implements Bekreftelse {
 
-    @JsonProperty("oppgaveReferanse")
-    private UUID oppgaveReferanse;
-
-    @JsonProperty("nyStartdato")
-    private LocalDate nyStartdato;
-
-    @JsonProperty("harUttalelse")
-    private boolean harUttalelse;
-
-    @JsonProperty("uttalelseFraBruker")
-    @Pattern(regexp = Patterns.FRITEKST, message = "[ugyldigSyntaks] matcher ikke tillatt pattern [{regexp}]")
-    @Size(max = 4000)
-    private String uttalelseFraBruker;
-
-    @JsonProperty("dataBruktTilUtledning")
-    private DataBruktTilUtledning dataBruktTilUtledning;
-
-    @JsonCreator
-    public EndretStartdatoBekreftelse(
-            @JsonProperty("oppgaveReferanse") UUID oppgaveReferanse,
-            @JsonProperty("nyStartdato") LocalDate nyStartdato,
-            @JsonProperty("harUttalelse") boolean harUttalelse) {
-        this.oppgaveReferanse = oppgaveReferanse;
-        this.nyStartdato = nyStartdato;
-        this.harUttalelse = harUttalelse;
+    public EndretStartdatoBekreftelse(UUID oppgaveReferanse, LocalDate nyStartdato, boolean harUttalelse) {
+        this(oppgaveReferanse, nyStartdato, harUttalelse, null, null);
     }
 
     public LocalDate getNyStartdato() {
@@ -49,6 +35,7 @@ public class EndretStartdatoBekreftelse implements Bekreftelse {
         return oppgaveReferanse;
     }
 
+    @JsonIgnore
     @Override
     public Type getType() {
         return Type.UNG_ENDRET_STARTDATO;
@@ -61,8 +48,7 @@ public class EndretStartdatoBekreftelse implements Bekreftelse {
 
     @Override
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
-        this.dataBruktTilUtledning = dataBruktTilUtledning;
-        return this;
+        return new EndretStartdatoBekreftelse(oppgaveReferanse, nyStartdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 
     @Override
@@ -71,12 +57,6 @@ public class EndretStartdatoBekreftelse implements Bekreftelse {
     }
 
     public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
-        this.uttalelseFraBruker = uttalelseFraBruker;
-        return this;
-    }
-
-    @Override
-    public boolean harUttalelse() {
-        return harUttalelse;
+        return new EndretStartdatoBekreftelse(oppgaveReferanse, nyStartdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretStartdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretStartdatoBekreftelse.java
@@ -47,6 +47,8 @@ public record EndretStartdatoBekreftelse(
     }
 
     @Override
+    // TODO(rydd): Vurder å gi denne metoden et mindre builder-liknende navn (f.eks. kloneMedDataBruktTilUtledning)
+    // siden dette i record er en kopimetode ("wither") som returnerer ny instans, ikke en muterende setter.
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
         return new EndretStartdatoBekreftelse(oppgaveReferanse, nyStartdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/FjernetPeriodeBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/FjernetPeriodeBekreftelse.java
@@ -47,6 +47,8 @@ public record FjernetPeriodeBekreftelse(
     }
 
     @Override
+    // TODO(rydd): Vurder å gi denne metoden et mindre builder-liknende navn (f.eks. kloneMedDataBruktTilUtledning)
+    // siden dette i record er en kopimetode ("wither") som returnerer ny instans, ikke en muterende setter.
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
         return new FjernetPeriodeBekreftelse(oppgaveReferanse, fjernetPeriode, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/FjernetPeriodeBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/FjernetPeriodeBekreftelse.java
@@ -1,7 +1,7 @@
 package no.nav.k9.oppgave.bekreftelse.ung.periodeendring;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.konstant.Patterns;
@@ -9,36 +9,21 @@ import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
 import no.nav.k9.søknad.felles.type.Periode;
 import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 
-import java.time.LocalDate;
 import java.util.UUID;
 
-public class FjernetPeriodeBekreftelse implements Bekreftelse {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FjernetPeriodeBekreftelse(
+        UUID oppgaveReferanse,
+        Periode fjernetPeriode,
+        boolean harUttalelse,
+        @Pattern(regexp = Patterns.FRITEKST, message = "[ugyldigSyntaks] matcher ikke tillatt pattern [{regexp}]")
+        @Size(max = 4000)
+        String uttalelseFraBruker,
+        DataBruktTilUtledning dataBruktTilUtledning
+) implements Bekreftelse {
 
-    @JsonProperty("oppgaveReferanse")
-    private UUID oppgaveReferanse;
-
-    @JsonProperty("fjernetPeriode")
-    private Periode fjernetPeriode;
-
-    @JsonProperty("harUttalelse")
-    private boolean harUttalelse;
-
-    @JsonProperty("uttalelseFraBruker")
-    @Pattern(regexp = Patterns.FRITEKST, message = "[ugyldigSyntaks] matcher ikke tillatt pattern [{regexp}]")
-    @Size(max = 4000)
-    private String uttalelseFraBruker;
-
-    @JsonProperty("dataBruktTilUtledning")
-    private DataBruktTilUtledning dataBruktTilUtledning;
-
-    @JsonCreator
-    public FjernetPeriodeBekreftelse(
-            @JsonProperty("oppgaveReferanse") UUID oppgaveReferanse,
-            @JsonProperty("fjernetPeriode") Periode fjernetPeriode,
-            @JsonProperty("harUttalelse") boolean harUttalelse) {
-        this.oppgaveReferanse = oppgaveReferanse;
-        this.fjernetPeriode = fjernetPeriode;
-        this.harUttalelse = harUttalelse;
+    public FjernetPeriodeBekreftelse(UUID oppgaveReferanse, Periode fjernetPeriode, boolean harUttalelse) {
+        this(oppgaveReferanse, fjernetPeriode, harUttalelse, null, null);
     }
 
     public Periode getFjernetPeriode() {
@@ -50,6 +35,7 @@ public class FjernetPeriodeBekreftelse implements Bekreftelse {
         return oppgaveReferanse;
     }
 
+    @JsonIgnore
     @Override
     public Type getType() {
         return Type.UNG_FJERNET_PERIODE;
@@ -62,8 +48,7 @@ public class FjernetPeriodeBekreftelse implements Bekreftelse {
 
     @Override
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
-        this.dataBruktTilUtledning = dataBruktTilUtledning;
-        return this;
+        return new FjernetPeriodeBekreftelse(oppgaveReferanse, fjernetPeriode, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 
     @Override
@@ -72,12 +57,6 @@ public class FjernetPeriodeBekreftelse implements Bekreftelse {
     }
 
     public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
-        this.uttalelseFraBruker = uttalelseFraBruker;
-        return this;
-    }
-
-    @Override
-    public boolean harUttalelse() {
-        return harUttalelse;
+        return new FjernetPeriodeBekreftelse(oppgaveReferanse, fjernetPeriode, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 }

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/BekreftelseSerialisertypeTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/BekreftelseSerialisertypeTest.java
@@ -1,0 +1,124 @@
+package no.nav.k9.oppgave;
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretPeriodeBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretSluttdatoBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretStartdatoBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.FjernetPeriodeBekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.felles.type.Periode;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regresjonstest for PR #598: Sikrer at type-feltet ikke serialiseres dobbelt
+ * og at deserialisering av eksisterende typer fungerer uten "Unrecognized field 'type'".
+ */
+class BekreftelseSerialisertypeTest {
+
+    @Test
+    void endretStartdato_roundtrip_uten_duplikat_type() {
+        var original = new EndretStartdatoBekreftelse(
+                UUID.fromString("00000000-0000-0000-0001-000000000001"),
+                LocalDate.of(2026, 1, 1),
+                false);
+
+        String json = JsonUtils.toString(original);
+
+        assertThat(antallForekomster(json, "\"type\""))
+                .as("type-feltet skal kun forekomme én gang i JSON")
+                .isEqualTo(1);
+
+        var roundtrip = (EndretStartdatoBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
+        assertThat(roundtrip.getNyStartdato()).isEqualTo(original.getNyStartdato());
+        assertThat(roundtrip.getOppgaveReferanse()).isEqualTo(original.getOppgaveReferanse());
+        assertThat(roundtrip.harUttalelse()).isEqualTo(original.harUttalelse());
+    }
+
+    @Test
+    void endretSluttdato_roundtrip_uten_duplikat_type() {
+        var original = new EndretSluttdatoBekreftelse(
+                UUID.fromString("00000000-0000-0000-0002-000000000001"),
+                LocalDate.of(2026, 6, 30),
+                true);
+
+        String json = JsonUtils.toString(original);
+
+        assertThat(antallForekomster(json, "\"type\""))
+                .as("type-feltet skal kun forekomme én gang i JSON")
+                .isEqualTo(1);
+
+        var roundtrip = (EndretSluttdatoBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
+        assertThat(roundtrip.getNySluttdato()).isEqualTo(original.getNySluttdato());
+        assertThat(roundtrip.getOppgaveReferanse()).isEqualTo(original.getOppgaveReferanse());
+    }
+
+    @Test
+    void endretPeriode_roundtrip_uten_duplikat_type() {
+        var original = new EndretPeriodeBekreftelse(
+                UUID.fromString("00000000-0000-0000-0003-000000000001"),
+                new Periode(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 6, 30)),
+                false);
+
+        String json = JsonUtils.toString(original);
+
+        assertThat(antallForekomster(json, "\"type\""))
+                .as("type-feltet skal kun forekomme én gang i JSON")
+                .isEqualTo(1);
+
+        var roundtrip = (EndretPeriodeBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
+        assertThat(roundtrip.getNyPeriode()).isEqualTo(original.getNyPeriode());
+        assertThat(roundtrip.getOppgaveReferanse()).isEqualTo(original.getOppgaveReferanse());
+    }
+
+    @Test
+    void fjernetPeriode_roundtrip_uten_duplikat_type() {
+        var original = new FjernetPeriodeBekreftelse(
+                UUID.fromString("00000000-0000-0000-0004-000000000001"),
+                new Periode(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 3, 31)),
+                false);
+
+        String json = JsonUtils.toString(original);
+
+        assertThat(antallForekomster(json, "\"type\""))
+                .as("type-feltet skal kun forekomme én gang i JSON")
+                .isEqualTo(1);
+
+        var roundtrip = (FjernetPeriodeBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
+        assertThat(roundtrip.getFjernetPeriode()).isEqualTo(original.getFjernetPeriode());
+        assertThat(roundtrip.getOppgaveReferanse()).isEqualTo(original.getOppgaveReferanse());
+    }
+
+    @Test
+    void deserialiser_json_med_ukjente_felter_feiler_ikke() {
+        // Simulerer bakoverkompatibilitet: JSON med et ekstra ukjent felt i tillegg til type-diskriminator
+        String json = """
+                {
+                  "type": "UNG_ENDRET_STARTDATO",
+                  "oppgaveReferanse": "00000000-0000-0000-0001-000000000002",
+                  "nyStartdato": "2026-01-01",
+                  "harUttalelse": false,
+                  "ukjentFremtidigFelt": "skalIgnoreres"
+                }
+                """;
+
+        var bekreftelse = (EndretStartdatoBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
+        assertThat(bekreftelse.getNyStartdato()).isEqualTo(LocalDate.of(2026, 1, 1));
+        assertThat(bekreftelse.getOppgaveReferanse()).isEqualTo(UUID.fromString("00000000-0000-0000-0001-000000000002"));
+    }
+
+    private static int antallForekomster(String tekst, String søk) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = tekst.indexOf(søk, idx)) != -1) {
+            count++;
+            idx += søk.length();
+        }
+        return count;
+    }
+}
+


### PR DESCRIPTION
### Behov / Bakgrunn

Etter PR #598 oppstod regresjon i oppgavebekreftelse-kontrakten i ung-sak ved parsing av bekreftelser (bl.a. for `UNG_ENDRET_STARTDATO` / `UNG_ENDRET_SLUTTDATO`):

- `Duplicate field 'type' for ObjectNode`
- `Unrecognized field "type"` (f.eks. i `EndretStartdatoBekreftelse`)

Målet er å sikre bakoverkompatibel kontrakt der `type` kun håndteres ett sted i JSON (polymorf typeinfo), uten duplikatfelt eller parse-feil.

### Løsning

- Konvertert følgende bekreftelser til `record`:
  - `EndretStartdatoBekreftelse`
  - `EndretSluttdatoBekreftelse`
  - `EndretPeriodeBekreftelse`
  - `FjernetPeriodeBekreftelse`
- Beholdt eksisterende API-flate (`get...`/`med...`) for minimal påvirkning hos konsumenter.
- Sikret stabil type-håndtering:
  - `type` kommer fra polymorf deserialisering på wrapper-nivå
  - ingen dobbel serialisering av `type` fra konkrete bekreftelser
- Beholdt robust deserialisering med `@JsonIgnoreProperties(ignoreUnknown = true)`.

### Andre endringer

- Lagt til regresjonstest i `soknad-jackson2og3-tester`:
  - `BekreftelseSerialisertypeTest`
- Testene verifiserer:
  - ingen duplisert `type` i JSON
  - vellykket deserialisering av eksisterende typer
  - stabil kontrakt for relevante UNG-bekreftelser
- Verifisert med både Jackson 2 og Jackson 3.