### PR TITLE
Renamer AutomatiskOpphørBekreftelse til OpphørVedMaksdatoBekreftelse.

### DIFF
--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/Bekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/Bekreftelse.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.validation.Valid;
 import no.nav.k9.oppgave.bekreftelse.ung.bosatt.BostedAvklaringBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.inntekt.InntektBekreftelse;
-import no.nav.k9.oppgave.bekreftelse.ung.opphor.AutomatiskOpphørBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.opphor.OpphørVedMaksdatoBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretPeriodeBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretSluttdatoBekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.periodeendring.EndretStartdatoBekreftelse;
@@ -25,7 +25,7 @@ import java.util.UUID;
         @JsonSubTypes.Type(name = Bekreftelse.UNG_FJERNET_PERIODE, value = FjernetPeriodeBekreftelse.class),
         @JsonSubTypes.Type(name = Bekreftelse.UNG_AVVIK_REGISTERINNTEKT, value = InntektBekreftelse.class),
         @JsonSubTypes.Type(name = Bekreftelse.AVP_BOSTED_AVKLARING, value = BostedAvklaringBekreftelse.class),
-        @JsonSubTypes.Type(name = Bekreftelse.UNG_AUTOMATISK_OPPHOR, value = AutomatiskOpphørBekreftelse.class),
+        @JsonSubTypes.Type(name = Bekreftelse.UNG_OPPHOR_VED_MAKDSDATO, value = OpphørVedMaksdatoBekreftelse.class),
 })
 public interface Bekreftelse {
 
@@ -35,7 +35,7 @@ public interface Bekreftelse {
     String UNG_FJERNET_PERIODE = "UNG_FJERNET_PERIODE";
     String UNG_AVVIK_REGISTERINNTEKT = "UNG_AVVIK_REGISTERINNTEKT";
     String AVP_BOSTED_AVKLARING = "AVP_BOSTED_AVKLARING";
-    String UNG_AUTOMATISK_OPPHOR = "UNG_AUTOMATISK_OPPHOR";
+    String UNG_OPPHOR_VED_MAKDSDATO = "UNG_OPPHOR_VED_MAKDSDATO";
 
     /**
      * Unik id for oppgaven som blir bekreftet
@@ -64,7 +64,7 @@ public interface Bekreftelse {
         UNG_FJERNET_PERIODE(Bekreftelse.UNG_FJERNET_PERIODE),
         UNG_AVVIK_REGISTERINNTEKT(Bekreftelse.UNG_AVVIK_REGISTERINNTEKT),
         AVP_BOSTED_AVKLARING(Bekreftelse.AVP_BOSTED_AVKLARING),
-        UNG_AUTOMATISK_OPPHOR(Bekreftelse.UNG_AUTOMATISK_OPPHOR);
+        UNG_OPPHOR_VED_MAKSDATO(Bekreftelse.UNG_OPPHOR_VED_MAKDSDATO);
 
 
         @JsonValue

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/Bekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/Bekreftelse.java
@@ -25,7 +25,7 @@ import java.util.UUID;
         @JsonSubTypes.Type(name = Bekreftelse.UNG_FJERNET_PERIODE, value = FjernetPeriodeBekreftelse.class),
         @JsonSubTypes.Type(name = Bekreftelse.UNG_AVVIK_REGISTERINNTEKT, value = InntektBekreftelse.class),
         @JsonSubTypes.Type(name = Bekreftelse.AVP_BOSTED_AVKLARING, value = BostedAvklaringBekreftelse.class),
-        @JsonSubTypes.Type(name = Bekreftelse.UNG_OPPHOR_VED_MAKDSDATO, value = OpphørVedMaksdatoBekreftelse.class),
+        @JsonSubTypes.Type(name = Bekreftelse.UNG_OPPHOR_VED_MAKSDATO, value = OpphørVedMaksdatoBekreftelse.class),
 })
 public interface Bekreftelse {
 
@@ -35,7 +35,7 @@ public interface Bekreftelse {
     String UNG_FJERNET_PERIODE = "UNG_FJERNET_PERIODE";
     String UNG_AVVIK_REGISTERINNTEKT = "UNG_AVVIK_REGISTERINNTEKT";
     String AVP_BOSTED_AVKLARING = "AVP_BOSTED_AVKLARING";
-    String UNG_OPPHOR_VED_MAKDSDATO = "UNG_OPPHOR_VED_MAKDSDATO";
+    String UNG_OPPHOR_VED_MAKSDATO = "UNG_OPPHOR_VED_MAKSDATO";
 
     /**
      * Unik id for oppgaven som blir bekreftet
@@ -64,7 +64,7 @@ public interface Bekreftelse {
         UNG_FJERNET_PERIODE(Bekreftelse.UNG_FJERNET_PERIODE),
         UNG_AVVIK_REGISTERINNTEKT(Bekreftelse.UNG_AVVIK_REGISTERINNTEKT),
         AVP_BOSTED_AVKLARING(Bekreftelse.AVP_BOSTED_AVKLARING),
-        UNG_OPPHOR_VED_MAKSDATO(Bekreftelse.UNG_OPPHOR_VED_MAKDSDATO);
+        UNG_OPPHOR_VED_MAKSDATO(Bekreftelse.UNG_OPPHOR_VED_MAKSDATO);
 
 
         @JsonValue

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/opphor/OpphørVedMaksdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/opphor/OpphørVedMaksdatoBekreftelse.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 /**
- * Bekreftelse fra bruker ved automatisk opphør av ungdomsprogramytelsen.
+ * Bekreftelse fra bruker ved opphør nær maksdato i ungdomsprogramytelsen.
  * Bruker kan bekrefte at de har lest varselet, eventuelt med en kommentar.
  *
  * <p>Merk: {@code @JsonIgnoreProperties("type")} er nødvendig fordi {@link Bekreftelse}-interfacet
@@ -19,7 +19,7 @@ import java.util.UUID;
  * uten annotasjonen.
  */
 @com.fasterxml.jackson.annotation.JsonIgnoreProperties("type")
-public record AutomatiskOpphørBekreftelse(
+public record OpphørVedMaksdatoBekreftelse(
         UUID oppgaveReferanse,
         LocalDate sluttdato,
         boolean harUttalelse,
@@ -29,7 +29,7 @@ public record AutomatiskOpphørBekreftelse(
         DataBruktTilUtledning dataBruktTilUtledning
 ) implements Bekreftelse {
 
-    public AutomatiskOpphørBekreftelse(UUID oppgaveReferanse, LocalDate sluttdato, boolean harUttalelse) {
+    public OpphørVedMaksdatoBekreftelse(UUID oppgaveReferanse, LocalDate sluttdato, boolean harUttalelse) {
         this(oppgaveReferanse, sluttdato, harUttalelse, null, null);
     }
 
@@ -59,17 +59,17 @@ public record AutomatiskOpphørBekreftelse(
 
     @Override
     public Type getType() {
-        return Type.UNG_AUTOMATISK_OPPHOR;
+        return Type.UNG_OPPHOR_VED_MAKSDATO;
     }
 
     @Override
     // TODO(rydd): Vurder å gi denne metoden et mindre builder-liknende navn (f.eks. kloneMedDataBruktTilUtledning)
     // siden dette i record er en kopimetode ("wither") som returnerer ny instans, ikke en muterende setter.
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
-        return new AutomatiskOpphørBekreftelse(oppgaveReferanse, sluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
+        return new OpphørVedMaksdatoBekreftelse(oppgaveReferanse, sluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 
     public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
-        return new AutomatiskOpphørBekreftelse(oppgaveReferanse, sluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
+        return new OpphørVedMaksdatoBekreftelse(oppgaveReferanse, sluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 }

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/OpphørVedMaksdatoBekreftelseTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/OpphørVedMaksdatoBekreftelseTest.java
@@ -1,7 +1,7 @@
 package no.nav.k9.oppgave;
 
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
-import no.nav.k9.oppgave.bekreftelse.ung.opphor.AutomatiskOpphørBekreftelse;
+import no.nav.k9.oppgave.bekreftelse.ung.opphor.OpphørVedMaksdatoBekreftelse;
 import no.nav.k9.søknad.JsonUtils;
 import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 import org.junit.jupiter.api.Test;
@@ -11,20 +11,20 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class AutomatiskOpphørBekreftelseTest {
+class OpphørVedMaksdatoBekreftelseTest {
 
     @Test
     void roundtrip_uten_valgfrie_felter() {
-        var original = new AutomatiskOpphørBekreftelse(
+        var original = new OpphørVedMaksdatoBekreftelse(
                 UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 LocalDate.of(2026, 5, 12),
                 true);
 
         String json = JsonUtils.toString(original);
-        var roundtrip = (AutomatiskOpphørBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
+        var roundtrip = (OpphørVedMaksdatoBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
 
         assertThat(roundtrip).isEqualTo(original);
-        assertThat(roundtrip.getType()).isEqualTo(Bekreftelse.Type.UNG_AUTOMATISK_OPPHOR);
+        assertThat(roundtrip.getType()).isEqualTo(Bekreftelse.Type.UNG_OPPHOR_VED_MAKSDATO);
         assertThat(roundtrip.getOppgaveReferanse()).isEqualTo(original.oppgaveReferanse());
         assertThat(roundtrip.getSluttdato()).isEqualTo(original.sluttdato());
         assertThat(roundtrip.harUttalelse()).isTrue();
@@ -32,7 +32,7 @@ class AutomatiskOpphørBekreftelseTest {
 
     @Test
     void roundtrip_med_uttalelse_og_dataBruktTilUtledning() {
-        var original = new AutomatiskOpphørBekreftelse(
+        var original = new OpphørVedMaksdatoBekreftelse(
                 UUID.fromString("00000000-0000-0000-0000-000000000002"),
                 LocalDate.of(2026, 5, 12),
                 true)
@@ -44,7 +44,7 @@ class AutomatiskOpphørBekreftelseTest {
                         .medHarForståttRettigheterOgPlikter(true));
 
         String json = JsonUtils.toString(medData);
-        var roundtrip = (AutomatiskOpphørBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
+        var roundtrip = (OpphørVedMaksdatoBekreftelse) JsonUtils.fromString(json, Bekreftelse.class);
 
         assertThat(roundtrip.oppgaveReferanse()).isEqualTo(UUID.fromString("00000000-0000-0000-0000-000000000002"));
         assertThat(roundtrip.sluttdato()).isEqualTo(LocalDate.of(2026, 5, 12));
@@ -56,7 +56,7 @@ class AutomatiskOpphørBekreftelseTest {
 
     @Test
     void json_inneholder_forventede_feltnavn() {
-        var bekreftelse = new AutomatiskOpphørBekreftelse(
+        var bekreftelse = new OpphørVedMaksdatoBekreftelse(
                 UUID.fromString("00000000-0000-0000-0000-000000000003"),
                 LocalDate.of(2026, 1, 31),
                 false);
@@ -70,13 +70,13 @@ class AutomatiskOpphørBekreftelseTest {
 
     @Test
     void med_metoder_gir_ny_instans_og_muterer_ikke_original() {
-        var original = new AutomatiskOpphørBekreftelse(
+        var original = new OpphørVedMaksdatoBekreftelse(
                 UUID.fromString("00000000-0000-0000-0000-000000000004"),
                 LocalDate.of(2026, 6, 1),
                 false);
 
-        var medUttalelse = (AutomatiskOpphørBekreftelse) original.medUttalelseFraBruker("kommentar");
-        var medData = (AutomatiskOpphørBekreftelse) original.medDataBruktTilUtledning(new DataBruktTilUtledning());
+        var medUttalelse = (OpphørVedMaksdatoBekreftelse) original.medUttalelseFraBruker("kommentar");
+        var medData = (OpphørVedMaksdatoBekreftelse) original.medDataBruktTilUtledning(new DataBruktTilUtledning());
 
         assertThat(original.getUttalelseFraBruker()).isNull();
         assertThat(original.getDataBruktTilUtledning()).isNull();


### PR DESCRIPTION
### Behov / Bakgrunn

Bekreftelse `UNG_OPPHOR_VED_MAKDSDATO` trenger semantisk klargjøring for å reflektere at opphøret skjer ved en beregnet maksdato basert på antall virkedager, ikke helt automatisk. Termo "opphør ved maksdato" er mer presis og reduserer forvirring om bekreftelsens formål.

Denne endringen legger grunnlag for senere funksjonalitet og implementering av bekreftelse typen.

### Løsning

Renamer `AutomatiskOpphørBekreftelse` til `OpphørVedMaksdatoBekreftelse` og tilknyttet type. 

