### PR TITLE
TSFF-2756 - fjerner medUttalelseFraBruker og bedre feilhåndtering av uttalelser 

### DIFF
--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/bosatt/BostedAvklaringBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/bosatt/BostedAvklaringBekreftelse.java
@@ -39,7 +39,7 @@ public class BostedAvklaringBekreftelse implements Bekreftelse {
 
     @JsonIgnore
     @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
-    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+    public boolean isUttalelseFraBrukerSattHvisHarUttalelse() {
         if (harUttalelse) {
             return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
         }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/bosatt/BostedAvklaringBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/bosatt/BostedAvklaringBekreftelse.java
@@ -1,9 +1,7 @@
 package no.nav.k9.oppgave.bekreftelse.ung.bosatt;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.konstant.Patterns;
@@ -37,6 +35,15 @@ public class BostedAvklaringBekreftelse implements Bekreftelse {
         this.oppgaveReferanse = oppgaveReferanse;
         this.harUttalelse = harUttalelse;
         this.uttalelseFraBruker = uttalelseFraBruker;
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
+    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+        if (harUttalelse) {
+            return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
+        }
+        return true;
     }
 
     @Override

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/inntekt/InntektBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/inntekt/InntektBekreftelse.java
@@ -44,7 +44,7 @@ public class InntektBekreftelse implements Bekreftelse {
 
     @JsonIgnore
     @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
-    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+    public boolean isUttalelseFraBrukerSattHvisHarUttalelse() {
         if (harUttalelse) {
             return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
         }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/inntekt/InntektBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/inntekt/InntektBekreftelse.java
@@ -1,9 +1,7 @@
 package no.nav.k9.oppgave.bekreftelse.ung.inntekt;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.konstant.Patterns;
@@ -42,6 +40,15 @@ public class InntektBekreftelse implements Bekreftelse {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
+    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+        if (harUttalelse) {
+            return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
+        }
+        return true;
     }
 
     @Override

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/opphor/OpphørVedMaksdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/opphor/OpphørVedMaksdatoBekreftelse.java
@@ -37,7 +37,7 @@ public record OpphørVedMaksdatoBekreftelse(
 
     @JsonIgnore
     @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
-    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+    public boolean isUttalelseFraBrukerSattHvisHarUttalelse() {
         if (harUttalelse) {
             return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
         }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/opphor/OpphørVedMaksdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/opphor/OpphørVedMaksdatoBekreftelse.java
@@ -1,5 +1,7 @@
 package no.nav.k9.oppgave.bekreftelse.ung.opphor;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.konstant.Patterns;
@@ -31,6 +33,15 @@ public record OpphørVedMaksdatoBekreftelse(
 
     public OpphørVedMaksdatoBekreftelse(UUID oppgaveReferanse, LocalDate sluttdato, boolean harUttalelse) {
         this(oppgaveReferanse, sluttdato, harUttalelse, null, null);
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
+    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+        if (harUttalelse) {
+            return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
+        }
+        return true;
     }
 
     @Override
@@ -66,10 +77,6 @@ public record OpphørVedMaksdatoBekreftelse(
     // TODO(rydd): Vurder å gi denne metoden et mindre builder-liknende navn (f.eks. kloneMedDataBruktTilUtledning)
     // siden dette i record er en kopimetode ("wither") som returnerer ny instans, ikke en muterende setter.
     public Bekreftelse medDataBruktTilUtledning(DataBruktTilUtledning dataBruktTilUtledning) {
-        return new OpphørVedMaksdatoBekreftelse(oppgaveReferanse, sluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
-    }
-
-    public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
         return new OpphørVedMaksdatoBekreftelse(oppgaveReferanse, sluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretPeriodeBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretPeriodeBekreftelse.java
@@ -30,7 +30,7 @@ public record EndretPeriodeBekreftelse(
 
     @JsonIgnore
     @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
-    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+    public boolean isUttalelseFraBrukerSattHvisHarUttalelse() {
         if (harUttalelse) {
             return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
         }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretPeriodeBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretPeriodeBekreftelse.java
@@ -2,6 +2,7 @@ package no.nav.k9.oppgave.bekreftelse.ung.periodeendring;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -25,6 +26,15 @@ public record EndretPeriodeBekreftelse(
 
     public EndretPeriodeBekreftelse(UUID oppgaveReferanse, Periode nyPeriode, boolean harUttalelse) {
         this(oppgaveReferanse, nyPeriode, harUttalelse, null, null);
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
+    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+        if (harUttalelse) {
+            return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
+        }
+        return true;
     }
 
     public Periode getNyPeriode() {
@@ -57,9 +67,5 @@ public record EndretPeriodeBekreftelse(
     @Override
     public String getUttalelseFraBruker() {
         return uttalelseFraBruker;
-    }
-
-    public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
-        return new EndretPeriodeBekreftelse(oppgaveReferanse, nyPeriode, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretSluttdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretSluttdatoBekreftelse.java
@@ -29,7 +29,7 @@ public record EndretSluttdatoBekreftelse(
 
     @JsonIgnore
     @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
-    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+    public boolean isUttalelseFraBrukerSattHvisHarUttalelse() {
         if (harUttalelse) {
             return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
         }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretSluttdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretSluttdatoBekreftelse.java
@@ -2,6 +2,7 @@ package no.nav.k9.oppgave.bekreftelse.ung.periodeendring;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.konstant.Patterns;
@@ -24,6 +25,15 @@ public record EndretSluttdatoBekreftelse(
 
     public EndretSluttdatoBekreftelse(UUID oppgaveReferanse, LocalDate nySluttdato, boolean harUttalelse) {
         this(oppgaveReferanse, nySluttdato, harUttalelse, null, null);
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
+    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+        if (harUttalelse) {
+            return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
+        }
+        return true;
     }
 
     public LocalDate getNySluttdato() {
@@ -56,9 +66,5 @@ public record EndretSluttdatoBekreftelse(
     @Override
     public String getUttalelseFraBruker() {
         return uttalelseFraBruker;
-    }
-
-    public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
-        return new EndretSluttdatoBekreftelse(oppgaveReferanse, nySluttdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretStartdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretStartdatoBekreftelse.java
@@ -29,7 +29,7 @@ public record EndretStartdatoBekreftelse(
 
     @JsonIgnore
     @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
-    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+    public boolean isUttalelseFraBrukerSattHvisHarUttalelse() {
         if (harUttalelse) {
             return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
         }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretStartdatoBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/EndretStartdatoBekreftelse.java
@@ -2,6 +2,7 @@ package no.nav.k9.oppgave.bekreftelse.ung.periodeendring;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.konstant.Patterns;
@@ -24,6 +25,15 @@ public record EndretStartdatoBekreftelse(
 
     public EndretStartdatoBekreftelse(UUID oppgaveReferanse, LocalDate nyStartdato, boolean harUttalelse) {
         this(oppgaveReferanse, nyStartdato, harUttalelse, null, null);
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
+    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+        if (harUttalelse) {
+            return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
+        }
+        return true;
     }
 
     public LocalDate getNyStartdato() {
@@ -56,9 +66,5 @@ public record EndretStartdatoBekreftelse(
     @Override
     public String getUttalelseFraBruker() {
         return uttalelseFraBruker;
-    }
-
-    public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
-        return new EndretStartdatoBekreftelse(oppgaveReferanse, nyStartdato, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/FjernetPeriodeBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/FjernetPeriodeBekreftelse.java
@@ -2,6 +2,7 @@ package no.nav.k9.oppgave.bekreftelse.ung.periodeendring;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import no.nav.k9.konstant.Patterns;
@@ -24,6 +25,15 @@ public record FjernetPeriodeBekreftelse(
 
     public FjernetPeriodeBekreftelse(UUID oppgaveReferanse, Periode fjernetPeriode, boolean harUttalelse) {
         this(oppgaveReferanse, fjernetPeriode, harUttalelse, null, null);
+    }
+
+    @JsonIgnore
+    @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
+    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+        if (harUttalelse) {
+            return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
+        }
+        return true;
     }
 
     public Periode getFjernetPeriode() {
@@ -56,9 +66,5 @@ public record FjernetPeriodeBekreftelse(
     @Override
     public String getUttalelseFraBruker() {
         return uttalelseFraBruker;
-    }
-
-    public Bekreftelse medUttalelseFraBruker(String uttalelseFraBruker) {
-        return new FjernetPeriodeBekreftelse(oppgaveReferanse, fjernetPeriode, harUttalelse, uttalelseFraBruker, dataBruktTilUtledning);
     }
 }

--- a/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/FjernetPeriodeBekreftelse.java
+++ b/oppgave-ungdomsytelse/src/main/java/no/nav/k9/oppgave/bekreftelse/ung/periodeendring/FjernetPeriodeBekreftelse.java
@@ -29,7 +29,7 @@ public record FjernetPeriodeBekreftelse(
 
     @JsonIgnore
     @AssertTrue(message = "uttalelseFraBruker må være satt dersom harUttalelse er true")
-    public boolean isUttalelseFraBrukerSattVedHarUttalelse() {
+    public boolean isUttalelseFraBrukerSattHvisHarUttalelse() {
         if (harUttalelse) {
             return uttalelseFraBruker != null && !uttalelseFraBruker.isBlank();
         }

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/BekreftelseValideringTestUtil.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/BekreftelseValideringTestUtil.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Felles testverktøy for {@link Bekreftelse}-implementasjoner: asserterer at
- * {@code @AssertTrue}-valideringen (isUttalelseFraBrukerSattVedHarUttalelse) kjøres etter parsing.
+ * {@code @AssertTrue}-valideringen (isUttalelseFraBrukerSattHvisHarUttalelse) kjøres etter parsing.
  */
 final class BekreftelseValideringTestUtil {
 

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/BekreftelseValideringTestUtil.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/BekreftelseValideringTestUtil.java
@@ -1,0 +1,39 @@
+package no.nav.k9.oppgave;
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.TestValidator;
+import no.nav.k9.søknad.felles.Feil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Felles testverktøy for {@link Bekreftelse}-implementasjoner: asserterer at
+ * {@code @AssertTrue}-valideringen (isUttalelseFraBrukerSattVedHarUttalelse) kjøres etter parsing.
+ */
+final class BekreftelseValideringTestUtil {
+
+    static final String FORVENTET_FEILMELDING =
+            "uttalelseFraBruker må være satt dersom harUttalelse er true";
+
+    private static final TestValidator VALIDATOR = new TestValidator();
+
+    private BekreftelseValideringTestUtil() {
+    }
+
+    /**
+     * Parser JSON og verifiserer at valideringen feiler med forventet feilmelding når
+     * {@code harUttalelse} er true men {@code uttalelseFraBruker} mangler.
+     */
+    static void assertManglendeUttalelseGirFeil(String json) {
+        var bekreftelse = JsonUtils.fromString(json, Bekreftelse.class);
+
+        var feil = VALIDATOR.verifyHarFeil(bekreftelse);
+        assertThat(feil)
+                .extracting(Feil::getFeilmelding)
+                .contains(FORVENTET_FEILMELDING);
+    }
+
+}
+
+

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/BostedAvklaringBekreftelseTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/BostedAvklaringBekreftelseTest.java
@@ -1,0 +1,36 @@
+package no.nav.k9.oppgave;
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.TestValidator;
+import org.junit.jupiter.api.Test;
+
+class BostedAvklaringBekreftelseTest {
+
+    @Test
+    void validering_feiler_når_harUttalelse_true_men_uttalelse_mangler() {
+        String json = """
+                {
+                  "type": "AVP_BOSTED_AVKLARING",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000006",
+                  "harUttalelse": true
+                }
+                """;
+        BekreftelseValideringTestUtil.assertManglendeUttalelseGirFeil(json);
+    }
+
+    @Test
+    void validering_ok_når_harUttalelse_true_og_uttalelse_satt() {
+        String json = """
+                {
+                  "type": "AVP_BOSTED_AVKLARING",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000006",
+                  "harUttalelse": true,
+                  "uttalelseFraBruker": "Jeg er enig"
+                }
+                """;
+
+        new TestValidator().verifyIngenFeil(JsonUtils.fromString(json, Bekreftelse.class));
+    }
+}
+

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/EndretPeriodeBekreftelseTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/EndretPeriodeBekreftelseTest.java
@@ -1,0 +1,36 @@
+package no.nav.k9.oppgave;
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.TestValidator;
+import org.junit.jupiter.api.Test;
+
+class EndretPeriodeBekreftelseTest {
+
+    @Test
+    void validering_feiler_når_harUttalelse_true_men_uttalelse_mangler() {
+        String json = """
+                {
+                  "type": "UNG_ENDRET_PERIODE",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000003",
+                  "harUttalelse": true
+                }
+                """;
+        BekreftelseValideringTestUtil.assertManglendeUttalelseGirFeil(json);
+    }
+
+    @Test
+    void validering_ok_når_harUttalelse_true_og_uttalelse_satt() {
+        String json = """
+                {
+                  "type": "UNG_ENDRET_PERIODE",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000003",
+                  "harUttalelse": true,
+                  "uttalelseFraBruker": "Jeg er enig"
+                }
+                """;
+
+        new TestValidator().verifyIngenFeil(JsonUtils.fromString(json, Bekreftelse.class));
+    }
+}
+

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/EndretSluttdatoBekreftelseTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/EndretSluttdatoBekreftelseTest.java
@@ -1,0 +1,38 @@
+package no.nav.k9.oppgave;
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.TestValidator;
+import org.junit.jupiter.api.Test;
+
+class EndretSluttdatoBekreftelseTest {
+
+    @Test
+    void validering_feiler_når_harUttalelse_true_men_uttalelse_mangler() {
+        String json = """
+                {
+                  "type": "UNG_ENDRET_SLUTTDATO",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000002",
+                  "nySluttdato": "2026-06-30",
+                  "harUttalelse": true
+                }
+                """;
+        BekreftelseValideringTestUtil.assertManglendeUttalelseGirFeil(json);
+    }
+
+    @Test
+    void validering_ok_når_harUttalelse_true_og_uttalelse_satt() {
+        String json = """
+                {
+                  "type": "UNG_ENDRET_SLUTTDATO",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000002",
+                  "nySluttdato": "2026-06-30",
+                  "harUttalelse": true,
+                  "uttalelseFraBruker": "Jeg er enig"
+                }
+                """;
+
+        new TestValidator().verifyIngenFeil(JsonUtils.fromString(json, Bekreftelse.class));
+    }
+}
+

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/EndretStartdatoBekreftelseTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/EndretStartdatoBekreftelseTest.java
@@ -1,0 +1,38 @@
+package no.nav.k9.oppgave;
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.TestValidator;
+import org.junit.jupiter.api.Test;
+
+class EndretStartdatoBekreftelseTest {
+
+    @Test
+    void validering_feiler_når_harUttalelse_true_men_uttalelse_mangler() {
+        String json = """
+                {
+                  "type": "UNG_ENDRET_STARTDATO",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000001",
+                  "nyStartdato": "2026-01-01",
+                  "harUttalelse": true
+                }
+                """;
+        BekreftelseValideringTestUtil.assertManglendeUttalelseGirFeil(json);
+    }
+
+    @Test
+    void validering_ok_når_harUttalelse_true_og_uttalelse_satt() {
+        String json = """
+                {
+                  "type": "UNG_ENDRET_STARTDATO",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000001",
+                  "nyStartdato": "2026-01-01",
+                  "harUttalelse": true,
+                  "uttalelseFraBruker": "Jeg er enig"
+                }
+                """;
+
+        new TestValidator().verifyIngenFeil(JsonUtils.fromString(json, Bekreftelse.class));
+    }
+}
+

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/FjernetPeriodeBekreftelseTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/FjernetPeriodeBekreftelseTest.java
@@ -1,0 +1,36 @@
+package no.nav.k9.oppgave;
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.TestValidator;
+import org.junit.jupiter.api.Test;
+
+class FjernetPeriodeBekreftelseTest {
+
+    @Test
+    void validering_feiler_når_harUttalelse_true_men_uttalelse_mangler() {
+        String json = """
+                {
+                  "type": "UNG_FJERNET_PERIODE",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000004",
+                  "harUttalelse": true
+                }
+                """;
+        BekreftelseValideringTestUtil.assertManglendeUttalelseGirFeil(json);
+    }
+
+    @Test
+    void validering_ok_når_harUttalelse_true_og_uttalelse_satt() {
+        String json = """
+                {
+                  "type": "UNG_FJERNET_PERIODE",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000004",
+                  "harUttalelse": true,
+                  "uttalelseFraBruker": "Jeg er enig"
+                }
+                """;
+
+        new TestValidator().verifyIngenFeil(JsonUtils.fromString(json, Bekreftelse.class));
+    }
+}
+

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/InntektBekreftelseTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/InntektBekreftelseTest.java
@@ -1,0 +1,36 @@
+package no.nav.k9.oppgave;
+
+import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
+import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.TestValidator;
+import org.junit.jupiter.api.Test;
+
+class InntektBekreftelseTest {
+
+    @Test
+    void validering_feiler_når_harUttalelse_true_men_uttalelse_mangler() {
+        String json = """
+                {
+                  "type": "UNG_AVVIK_REGISTERINNTEKT",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000005",
+                  "harUttalelse": true
+                }
+                """;
+        BekreftelseValideringTestUtil.assertManglendeUttalelseGirFeil(json);
+    }
+
+    @Test
+    void validering_ok_når_harUttalelse_true_og_uttalelse_satt() {
+        String json = """
+                {
+                  "type": "UNG_AVVIK_REGISTERINNTEKT",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000005",
+                  "harUttalelse": true,
+                  "uttalelseFraBruker": "Jeg er enig"
+                }
+                """;
+
+        new TestValidator().verifyIngenFeil(JsonUtils.fromString(json, Bekreftelse.class));
+    }
+}
+

--- a/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/OpphørVedMaksdatoBekreftelseTest.java
+++ b/soknad-jackson2og3-tester/src/test/java/no/nav/k9/oppgave/OpphørVedMaksdatoBekreftelseTest.java
@@ -3,6 +3,7 @@ package no.nav.k9.oppgave;
 import no.nav.k9.oppgave.bekreftelse.Bekreftelse;
 import no.nav.k9.oppgave.bekreftelse.ung.opphor.OpphørVedMaksdatoBekreftelse;
 import no.nav.k9.søknad.JsonUtils;
+import no.nav.k9.søknad.TestValidator;
 import no.nav.k9.søknad.ytelse.DataBruktTilUtledning;
 import org.junit.jupiter.api.Test;
 
@@ -35,8 +36,9 @@ class OpphørVedMaksdatoBekreftelseTest {
         var original = new OpphørVedMaksdatoBekreftelse(
                 UUID.fromString("00000000-0000-0000-0000-000000000002"),
                 LocalDate.of(2026, 5, 12),
-                true)
-                .medUttalelseFraBruker("Jeg er uenig i dette vedtaket");
+                true,
+                "Jeg er uenig i dette vedtaket",
+                null);
 
         var medData = original.medDataBruktTilUtledning(
                 new DataBruktTilUtledning()
@@ -75,12 +77,45 @@ class OpphørVedMaksdatoBekreftelseTest {
                 LocalDate.of(2026, 6, 1),
                 false);
 
-        var medUttalelse = (OpphørVedMaksdatoBekreftelse) original.medUttalelseFraBruker("kommentar");
+        var medUttalelse = new OpphørVedMaksdatoBekreftelse(
+                original.oppgaveReferanse(),
+                original.sluttdato(),
+                original.harUttalelse(),
+                "kommentar",
+                null);
         var medData = (OpphørVedMaksdatoBekreftelse) original.medDataBruktTilUtledning(new DataBruktTilUtledning());
 
         assertThat(original.getUttalelseFraBruker()).isNull();
         assertThat(original.getDataBruktTilUtledning()).isNull();
         assertThat(medUttalelse.getUttalelseFraBruker()).isEqualTo("kommentar");
         assertThat(medData.getDataBruktTilUtledning()).isNotNull();
+    }
+
+    @Test
+    void validering_feiler_når_harUttalelse_true_men_uttalelse_mangler() {
+        String json = """
+                {
+                  "type": "UNG_OPPHOR_VED_MAKSDATO",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000007",
+                  "sluttdato": "2026-05-12",
+                  "harUttalelse": true
+                }
+                """;
+        BekreftelseValideringTestUtil.assertManglendeUttalelseGirFeil(json);
+    }
+
+    @Test
+    void validering_ok_når_harUttalelse_true_og_uttalelse_satt() {
+        String json = """
+                {
+                  "type": "UNG_OPPHOR_VED_MAKSDATO",
+                  "oppgaveReferanse": "00000000-0000-0000-0000-000000000007",
+                  "sluttdato": "2026-05-12",
+                  "harUttalelse": true,
+                  "uttalelseFraBruker": "Jeg er enig"
+                }
+                """;
+
+        new TestValidator().verifyIngenFeil(JsonUtils.fromString(json, Bekreftelse.class));
     }
 }


### PR DESCRIPTION
### Behov / Bakgrunn
medUttalelseFraBruker hinter om mutasjon men i virkeligheten lages det en kopi i mange av Bekreftelse impl (innført i https://github.com/navikt/k9-format/pull/610) . Dette førte til feil i k9-brukerdialog-prosessering der uttalelser ikke ble overført til ung-sak. 

### Løsning
Fjernet metoden. Fjerner bruken av metoden i https://github.com/navikt/k9-brukerdialog-prosessering/pull/538. Legger i tillegg til validering og test av uttalelseFraBruker. 

